### PR TITLE
Fix KakaoProvider to use base URL and app key

### DIFF
--- a/src/main/java/com/und/server/oauth/KakaoProvider.java
+++ b/src/main/java/com/und/server/oauth/KakaoProvider.java
@@ -3,19 +3,31 @@ package com.und.server.oauth;
 import java.security.PublicKey;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.und.server.dto.OidcPublicKeys;
 import com.und.server.jwt.JwtProvider;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class KakaoProvider implements OidcProvider {
 
 	private final JwtProvider jwtProvider;
 	private final PublicKeyProvider publicKeyProvider;
+	private final String kakaoBaseUrl;
+	private final String kakaoAppKey;
+
+	public KakaoProvider(
+		JwtProvider jwtProvider,
+		PublicKeyProvider publicKeyProvider,
+		@Value("${oauth.kakao.base-url}") String kakaoBaseUrl,
+		@Value("${oauth.kakao.app-key}") String kakaoAppKey
+	) {
+		this.jwtProvider = jwtProvider;
+		this.publicKeyProvider = publicKeyProvider;
+		this.kakaoBaseUrl = kakaoBaseUrl;
+		this.kakaoAppKey = kakaoAppKey;
+	}
 
 	@Override
 	public String getOidcProviderId(String token, OidcPublicKeys oidcPublicKeys) {
@@ -24,8 +36,8 @@ public class KakaoProvider implements OidcProvider {
 
 		return jwtProvider.parseOidcSubjectFromIdToken(
 			token,
-			"${oauth.kakao.base-url}",
-			"${oauth.kakao.app-key}",
+			kakaoBaseUrl,
+			kakaoAppKey,
 			publicKey
 		);
 	}

--- a/src/test/java/com/und/server/oauth/KakaoProviderTest.java
+++ b/src/test/java/com/und/server/oauth/KakaoProviderTest.java
@@ -6,9 +6,9 @@ import static org.mockito.Mockito.when;
 import java.security.PublicKey;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -30,17 +30,24 @@ class KakaoProviderTest {
 	@Mock
 	private PublicKey publicKey;
 
-	@InjectMocks
 	private KakaoProvider kakaoProvider;
 
 	private final String token = "dummyToken";
+
+	private final String kakaoBaseUrl = "https://kauth.kakao.com";
+	private final String kakaoAppKey = "dummyAppKey";
+
+	@BeforeEach
+	void init() {
+		kakaoProvider = new KakaoProvider(jwtProvider, publicKeyProvider, kakaoBaseUrl, kakaoAppKey);
+	}
 
 	@Test
 	void getOidcProviderIdSuccessfully() {
 		final Map<String, String> decodedHeader = Map.of("alg", "RS256", "kid", "key1");
 		final String subject = "166959";
-		final String issuer = "${oauth.kakao.base-url}";
-		final String audience = "${oauth.kakao.app-key}";
+		final String issuer = kakaoBaseUrl;
+		final String audience = kakaoAppKey;
 
 		// given
 		when(jwtProvider.getDecodedHeader(token)).thenReturn(decodedHeader);


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] fix: 버그 수정

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
hotfix/login -> main

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
KakaoProvider에서 BaseURL과 AppKey를 `application.yml`에서 읽어오도록 수정했습니다.

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="1242" alt="Screenshot 2025-06-26 at 8 46 50 PM" src="https://github.com/user-attachments/assets/7c3f84eb-f5a6-48da-9aba-adf014ac7780" />

### 📂 관련 이슈
<!-- 예) #5 -->
#11 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
