### PR TITLE
Set start period to 90 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8080
 
 EXPOSE 10090
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+HEALTHCHECK --start-period=90s --interval=15s --timeout=5s --retries=3 \
   CMD ["wget", "--quiet", "--spider", "http://localhost:10090/actuator/health"]
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] cicd: 지속적 통합 및 배포 작업

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
cicd/docker -> main

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
Health check 시작 대기 시간을 90초로 연장

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

### 📂 관련 이슈
<!-- 예) #5 -->

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
