### PR TITLE
Add Logout API

### DIFF
--- a/.github/workflows/notify-on-comment.yml
+++ b/.github/workflows/notify-on-comment.yml
@@ -1,0 +1,67 @@
+name: Notify on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+
+permissions:
+  contents: read
+
+jobs:
+  notify-on-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send PR Comment Notification
+        if: github.event.issue.pull_request
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "A new comment has been added to the pull request 💬"
+        env:
+          DISCORD_WEBHOOK: ${{ env.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: |
+            [
+              {
+                "author": {
+                  "name": "${{ github.event.comment.user.login }}"
+                },
+                "title": "Comment on PR #${{ github.event.issue.number }}: ${{ github.event.issue.title }}",
+                "color": 10478271,
+                "description": "${{ github.event.comment.body }}\n\n[View Comment](${{ github.event.comment.html_url }})",
+                "fields": [
+                  {
+                    "name": "Pull Request",
+                    "value": "[Link](${{ github.event.issue.html_url }})",
+                    "inline": true
+                  }
+                ]
+              }
+            ]
+
+      - name: Send Issue Comment Notification
+        if: ${{ !github.event.issue.pull_request }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "A new comment has been added to the issue 💬"
+        env:
+          DISCORD_WEBHOOK: ${{ env.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: |
+            [
+              {
+                "author": {
+                  "name": "${{ github.event.comment.user.login }}"
+                },
+                "title": "Comment on Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}",
+                "color": 10478271,
+                "description": "${{ github.event.comment.body }}\n\n[View Comment](${{ github.event.comment.html_url }})",
+                "fields": [
+                  {
+                    "name": "Issue",
+                    "value": "[Link](${{ github.event.issue.html_url }})",
+                    "inline": true
+                  }
+                ]
+              }
+            ]

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/und/server/config/WebMvcConfig.java
+++ b/src/main/java/com/und/server/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.und.server.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.und.server.security.AuthMemberArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+	private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authMemberArgumentResolver);
+	}
+}

--- a/src/main/java/com/und/server/controller/AuthController.java
+++ b/src/main/java/com/und/server/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.und.server.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,10 +13,10 @@ import com.und.server.dto.AuthResponse;
 import com.und.server.dto.NonceRequest;
 import com.und.server.dto.NonceResponse;
 import com.und.server.dto.RefreshTokenRequest;
-import com.und.server.exception.ServerErrorResult;
-import com.und.server.exception.ServerException;
+import com.und.server.security.AuthMember;
 import com.und.server.service.AuthService;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -52,12 +51,8 @@ public class AuthController {
 	}
 
 	@DeleteMapping("/logout")
-	public ResponseEntity<Void> logout(final Authentication authentication) {
-		if (!(authentication.getPrincipal() instanceof final Long memberId)) {
-			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
-		}
+	public ResponseEntity<Void> logout(@Parameter(hidden = true) @AuthMember final Long memberId) {
 		authService.logout(memberId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
-
 }

--- a/src/main/java/com/und/server/controller/AuthController.java
+++ b/src/main/java/com/und/server/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.und.server.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +14,8 @@ import com.und.server.dto.AuthResponse;
 import com.und.server.dto.NonceRequest;
 import com.und.server.dto.NonceResponse;
 import com.und.server.dto.RefreshTokenRequest;
+import com.und.server.exception.ServerErrorResult;
+import com.und.server.exception.ServerException;
 import com.und.server.service.AuthService;
 
 import jakarta.validation.Valid;
@@ -45,6 +49,15 @@ public class AuthController {
 		final AuthResponse authResponse = authService.reissueTokens(refreshTokenRequest);
 
 		return ResponseEntity.status(HttpStatus.OK).body(authResponse);
+	}
+
+	@DeleteMapping("/logout")
+	public ResponseEntity<Void> logout(final Authentication authentication) {
+		if (!(authentication.getPrincipal() instanceof final Long memberId)) {
+			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
+		}
+		authService.logout(memberId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 }

--- a/src/main/java/com/und/server/controller/TestController.java
+++ b/src/main/java/com/und/server/controller/TestController.java
@@ -3,7 +3,6 @@ package com.und.server.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,9 +15,11 @@ import com.und.server.dto.TestHelloResponse;
 import com.und.server.entity.Member;
 import com.und.server.exception.ServerErrorResult;
 import com.und.server.exception.ServerException;
+import com.und.server.security.AuthMember;
 import com.und.server.service.AuthService;
 import com.und.server.service.MemberService;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -37,10 +38,7 @@ public class TestController {
 	}
 
 	@GetMapping("/hello")
-	public ResponseEntity<TestHelloResponse> greet(final Authentication authentication) {
-		if (!(authentication.getPrincipal() instanceof final Long memberId)) {
-			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
-		}
+	public ResponseEntity<TestHelloResponse> greet(@Parameter(hidden = true) @AuthMember final Long memberId) {
 		final Member member = memberService.findById(memberId)
 			.orElseThrow(() -> new ServerException(ServerErrorResult.MEMBER_NOT_FOUND));
 		final String nickname = member.getNickname() != null ? member.getNickname() : "Member";

--- a/src/main/java/com/und/server/controller/TestController.java
+++ b/src/main/java/com/und/server/controller/TestController.java
@@ -31,14 +31,16 @@ public class TestController {
 	private final MemberService memberService;
 
 	@PostMapping("/access")
-	public ResponseEntity<AuthResponse> requireAccessToken(@RequestBody @Valid TestAuthRequest request) {
+	public ResponseEntity<AuthResponse> requireAccessToken(@RequestBody @Valid final TestAuthRequest request) {
 		final AuthResponse response = authService.issueTokensForTest(request);
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 	@GetMapping("/hello")
-	public ResponseEntity<TestHelloResponse> greet(Authentication authentication) {
-		final Long memberId = (Long)authentication.getPrincipal();
+	public ResponseEntity<TestHelloResponse> greet(final Authentication authentication) {
+		if (!(authentication.getPrincipal() instanceof final Long memberId)) {
+			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
+		}
 		final Member member = memberService.findById(memberId)
 			.orElseThrow(() -> new ServerException(ServerErrorResult.MEMBER_NOT_FOUND));
 		final String nickname = member.getNickname() != null ? member.getNickname() : "Member";

--- a/src/main/java/com/und/server/jwt/JwtProvider.java
+++ b/src/main/java/com/und/server/jwt/JwtProvider.java
@@ -123,7 +123,7 @@ public class JwtProvider {
 					.parseSignedClaims(token)
 					.getPayload();
 		} catch (final ExpiredJwtException e) {
-			// This must be re-thrown for getMemberIdFromExpiredAccessToken to work correctly.
+			// This must be re-thrown for parseTokenForReissue to work correctly.
 			throw e;
 		} catch (final JwtException e) {
 			// For prod or stg environments, return a generic error to avoid leaking details.

--- a/src/main/java/com/und/server/security/AuthMember.java
+++ b/src/main/java/com/und/server/security/AuthMember.java
@@ -1,0 +1,11 @@
+package com.und.server.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+}

--- a/src/main/java/com/und/server/security/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/und/server/security/AuthMemberArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.und.server.security;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.und.server.exception.ServerErrorResult;
+import com.und.server.exception.ServerException;
+
+@Component
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(final MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthMember.class)
+			&& parameter.getParameterType().equals(Long.class);
+	}
+
+	@Override
+	public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+		final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !(authentication.getPrincipal() instanceof final Long memberId)) {
+			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
+		}
+		return memberId;
+	}
+
+}

--- a/src/main/java/com/und/server/service/AuthService.java
+++ b/src/main/java/com/und/server/service/AuthService.java
@@ -85,6 +85,11 @@ public class AuthService {
 		return issueTokens(memberId);
 	}
 
+	@Transactional
+	public void logout(final Long memberId) {
+		refreshTokenService.deleteRefreshToken(memberId);
+	}
+
 	private Provider convertToProvider(final String providerName) {
 		try {
 			return Provider.valueOf(providerName.toUpperCase());

--- a/src/test/java/com/und/server/controller/TestControllerTest.java
+++ b/src/test/java/com/und/server/controller/TestControllerTest.java
@@ -186,4 +186,24 @@ class TestControllerTest {
 			.andExpect(jsonPath("$.message").value("Hello, Member!"));
 	}
 
+	@Test
+	@DisplayName("Fails to greet and returns unauthorized when principal is not a Long")
+	void Given_InvalidPrincipalType_When_Greet_Then_ReturnsUnauthorized() throws Exception {
+		// given
+		final String url = "/v1/test/hello";
+		final String invalidPrincipal = "not-a-long";
+		final Authentication auth = new UsernamePasswordAuthenticationToken(invalidPrincipal, null);
+		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+
+		// when
+		final ResultActions result = mockMvc.perform(
+			MockMvcRequestBuilders.get(url).principal(auth)
+		);
+
+		// then
+		result.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(errorResult.name()))
+			.andExpect(jsonPath("$.message").value(errorResult.getMessage()));
+	}
+
 }

--- a/src/test/java/com/und/server/jwt/JwtProviderTest.java
+++ b/src/test/java/com/und/server/jwt/JwtProviderTest.java
@@ -243,7 +243,7 @@ class JwtProviderTest {
 		final Map<String, String> header = jwtProvider.getDecodedHeader(token);
 
 		// then
-		assertThat(header.get("alg")).isNotBlank();
+		assertThat(header.get("alg")).isEqualTo("HS256");
 	}
 
 	@Test

--- a/src/test/java/com/und/server/oauth/KakaoProviderTest.java
+++ b/src/test/java/com/und/server/oauth/KakaoProviderTest.java
@@ -1,7 +1,7 @@
 package com.und.server.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 import java.security.PublicKey;
 import java.util.Map;
@@ -51,9 +51,9 @@ class KakaoProviderTest {
 		final Map<String, String> decodedHeader = Map.of("alg", "RS256", "kid", "key1");
 		final IdTokenPayload expectedPayload = new IdTokenPayload(providerId, nickname);
 
-		when(jwtProvider.getDecodedHeader(token)).thenReturn(decodedHeader);
-		when(publicKeyProvider.generatePublicKey(decodedHeader, oidcPublicKeys)).thenReturn(publicKey);
-		when(jwtProvider.parseOidcIdToken(token, kakaoBaseUrl, kakaoAppKey, publicKey)).thenReturn(expectedPayload);
+		doReturn(decodedHeader).when(jwtProvider).getDecodedHeader(token);
+		doReturn(publicKey).when(publicKeyProvider).generatePublicKey(decodedHeader, oidcPublicKeys);
+		doReturn(expectedPayload).when(jwtProvider).parseOidcIdToken(token, kakaoBaseUrl, kakaoAppKey, publicKey);
 
 		// when
 		final IdTokenPayload actualPayload = kakaoProvider.getIdTokenPayload(token, oidcPublicKeys);

--- a/src/test/java/com/und/server/oauth/OidcProviderFactoryTest.java
+++ b/src/test/java/com/und/server/oauth/OidcProviderFactoryTest.java
@@ -2,7 +2,7 @@ package com.und.server.oauth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,7 +50,7 @@ class OidcProviderFactoryTest {
 		// given
 		final IdTokenPayload expectedPayload = new IdTokenPayload(providerId, nickname);
 
-		when(kakaoProvider.getIdTokenPayload(token, oidcPublicKeys)).thenReturn(expectedPayload);
+		doReturn(expectedPayload).when(kakaoProvider).getIdTokenPayload(token, oidcPublicKeys);
 
 		// when
 		final IdTokenPayload actualPayload = factory.getIdTokenPayload(Provider.KAKAO, token, oidcPublicKeys);

--- a/src/test/java/com/und/server/security/AuthMemberArgumentResolverTest.java
+++ b/src/test/java/com/und/server/security/AuthMemberArgumentResolverTest.java
@@ -1,0 +1,110 @@
+package com.und.server.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.und.server.exception.ServerErrorResult;
+import com.und.server.exception.ServerException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthMemberArgumentResolverTest {
+
+	@InjectMocks
+	private AuthMemberArgumentResolver authMemberArgumentResolver;
+
+	@Mock
+	private MethodParameter parameter;
+
+	@Mock
+	private SecurityContext securityContext;
+
+	@BeforeEach
+	void setUp() {
+		SecurityContextHolder.setContext(securityContext);
+	}
+
+	@Test
+	@DisplayName("Supports parameter with @AuthMember and Long type")
+	void Given_AuthMemberAnnotationAndLongType_When_SupportsParameter_Then_ReturnsTrue() {
+		// given
+		doReturn(true).when(parameter).hasParameterAnnotation(AuthMember.class);
+		doReturn(Long.class).when(parameter).getParameterType();
+
+		// when
+		final boolean result = authMemberArgumentResolver.supportsParameter(parameter);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("Does not support parameter without @AuthMember annotation")
+	void Given_NoAuthMemberAnnotation_When_SupportsParameter_Then_ReturnsFalse() {
+		// given
+		doReturn(false).when(parameter).hasParameterAnnotation(AuthMember.class);
+
+		// when
+		final boolean result = authMemberArgumentResolver.supportsParameter(parameter);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("Does not support parameter with @AuthMember but not Long type")
+	void Given_AuthMemberAnnotationButNotLongType_When_SupportsParameter_Then_ReturnsFalse() {
+		// given
+		doReturn(true).when(parameter).hasParameterAnnotation(AuthMember.class);
+		doReturn(String.class).when(parameter).getParameterType();
+
+		// when
+		final boolean result = authMemberArgumentResolver.supportsParameter(parameter);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("Resolves memberId successfully when principal is a Long")
+	void Given_ValidPrincipal_When_ResolveArgument_Then_ReturnsMemberId() {
+		// given
+		final Long memberId = 1L;
+		final UsernamePasswordAuthenticationToken authentication
+			= new UsernamePasswordAuthenticationToken(memberId, null);
+		doReturn(authentication).when(securityContext).getAuthentication();
+
+		// when
+		final Object result = authMemberArgumentResolver.resolveArgument(parameter, null, null, null);
+
+		// then
+		assertThat(result).isEqualTo(memberId);
+	}
+
+	@Test
+	@DisplayName("Throws ServerException when principal is not a Long")
+	void Given_InvalidPrincipalType_When_ResolveArgument_Then_ThrowsServerException() {
+		// given
+		final String invalidPrincipal = "not-a-long";
+		final UsernamePasswordAuthenticationToken authentication
+			= new UsernamePasswordAuthenticationToken(invalidPrincipal, null);
+		doReturn(authentication).when(securityContext).getAuthentication();
+
+		// when & then
+		assertThatThrownBy(() -> authMemberArgumentResolver.resolveArgument(parameter, null, null, null))
+			.isInstanceOf(ServerException.class)
+			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.UNAUTHORIZED_ACCESS);
+	}
+}

--- a/src/test/java/com/und/server/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/und/server/security/JwtAuthenticationFilterTest.java
@@ -2,10 +2,11 @@ package com.und.server.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
@@ -65,7 +66,7 @@ class JwtAuthenticationFilterTest {
 		request.addHeader("Authorization", "Bearer " + token);
 
 		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
-		when(jwtProvider.getAuthentication(token)).thenThrow(new ServerException(expectedError));
+		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
 		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -95,7 +96,7 @@ class JwtAuthenticationFilterTest {
 		request.addHeader("Authorization", "Bearer " + token);
 
 		final ServerErrorResult expectedError = ServerErrorResult.INVALID_TOKEN_SIGNATURE;
-		when(jwtProvider.getAuthentication(token)).thenThrow(new ServerException(expectedError));
+		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
 		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -125,7 +126,7 @@ class JwtAuthenticationFilterTest {
 		request.addHeader("Authorization", "Bearer " + token);
 
 		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
-		when(jwtProvider.getAuthentication(token)).thenThrow(new ServerException(expectedError));
+		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
 		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -150,7 +151,7 @@ class JwtAuthenticationFilterTest {
 		request.addHeader("Authorization", "Bearer " + token);
 
 		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
-		when(jwtProvider.getAuthentication(token)).thenThrow(new ServerException(expectedError));
+		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
 		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -206,7 +207,7 @@ class JwtAuthenticationFilterTest {
 		request.addHeader("Authorization", "Bearer " + token);
 
 		final Authentication authentication = mock(Authentication.class);
-		when(jwtProvider.getAuthentication(token)).thenReturn(authentication);
+		doReturn(authentication).when(jwtProvider).getAuthentication(token);
 
 		// when
 		jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);

--- a/src/test/java/com/und/server/service/AuthServiceTest.java
+++ b/src/test/java/com/und/server/service/AuthServiceTest.java
@@ -346,6 +346,19 @@ class AuthServiceTest {
 		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.NOT_EXPIRED_TOKEN);
 	}
 
+	@Test
+	@DisplayName("Deletes refresh token on logout")
+	void Given_MemberId_When_Logout_Then_DeletesRefreshToken() {
+		// given
+		final Long memberId = 1L;
+
+		// when
+		authService.logout(memberId);
+
+		// then
+		verify(refreshTokenService).deleteRefreshToken(memberId);
+	}
+
 	private void setupTokenIssuance(final String newAccessToken, final String newRefreshToken) {
 		doReturn(newAccessToken).when(jwtProvider).generateAccessToken(memberId);
 		doReturn(newRefreshToken).when(refreshTokenService).generateRefreshToken();


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] feat: 새로운 기능 추가

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
feat/logout -> dev

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
AuthController에 로그아웃 API 생성했습니다. 로그아웃 API는 성공적으로 처리된 경우 204 응답코드 반환합니다.
AuthService에 로그아웃 로직 구현했습니다. 로그아웃 로직은 다음과 같습니다.
1) 클라이언트에서 헤더에 사용자 인증 정보를 담아 보낼 시 해당 인증 정보에서 memberId를 확인
2) Redis에 저장된 Refresh Token 중 추출한 memberId에 맞는 Refresh Token을 찾아 폐기

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="1366" height="293" alt="Screenshot 2025-07-30 at 8 32 54 PM" src="https://github.com/user-attachments/assets/f626a418-40df-445a-832c-ba454325c90d" />

### 📂 관련 이슈
<!-- 예) #5 -->
#69 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
JWT 특성상 사용자에게 발급된 Access Token을 정지시킬 수 없어 대안으로 Refresh Token을 폐기하는 식으로 로그아웃을 구현했습니다. 사용자가 로그아웃을 했을 때 마지막으로 액세스 토큰을 발급받은 시점부터 30분이 지나면 더 이상 API 호출을 하지 못하게 됩니다.