### PR TITLE
Add change nickname API

### DIFF
--- a/src/main/java/com/und/server/auth/dto/AuthRequest.java
+++ b/src/main/java/com/und/server/auth/dto/AuthRequest.java
@@ -1,15 +1,13 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Request for Authentication with ID Token")
 public record AuthRequest(
 	@Schema(description = "OAuth provider name", example = "kakao")
-	@NotBlank(message = "Provider name must not be blank") @JsonProperty("provider") String provider,
+	@NotBlank(message = "Provider name must not be blank") String provider,
 
 	@Schema(description = "ID Token from the OAuth provider", example = "eyJhbGciOiJIUzI1Ni...")
-	@NotBlank(message = "ID Token must not be blank") @JsonProperty("id_token") String idToken
+	@NotBlank(message = "ID Token must not be blank") String idToken
 ) { }

--- a/src/main/java/com/und/server/auth/dto/AuthResponse.java
+++ b/src/main/java/com/und/server/auth/dto/AuthResponse.java
@@ -1,23 +1,21 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Authentication Token Response")
 public record AuthResponse(
 	@Schema(description = "Token type", example = "Bearer")
-	@JsonProperty("token_type") String tokenType,
+	String tokenType,
 
 	@Schema(description = "Access Token for API authentication", example = "eyJhbGciOiJIUzI1Ni...")
-	@JsonProperty("access_token") String accessToken,
+	String accessToken,
 
 	@Schema(description = "Access Token expiration time in seconds", example = "3600")
-	@JsonProperty("access_token_expires_in") Integer accessTokenExpiresIn,
+	Integer accessTokenExpiresIn,
 
 	@Schema(description = "Refresh Token for renewing the Access Token", example = "a1b2c3d4-e5f6-78...")
-	@JsonProperty("refresh_token") String refreshToken,
+	String refreshToken,
 
 	@Schema(description = "Refresh Token expiration time in seconds", example = "604800")
-	@JsonProperty("refresh_token_expires_in") Integer refreshTokenExpiresIn
+	Integer refreshTokenExpiresIn
 ) { }

--- a/src/main/java/com/und/server/auth/dto/NonceRequest.java
+++ b/src/main/java/com/und/server/auth/dto/NonceRequest.java
@@ -1,12 +1,10 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Request for issuing a Nonce")
 public record NonceRequest(
 	@Schema(description = "OAuth provider name", example = "kakao")
-	@NotBlank(message = "Provider name must not be blank") @JsonProperty("provider") String provider
+	@NotBlank(message = "Provider name must not be blank") String provider
 ) { }

--- a/src/main/java/com/und/server/auth/dto/NonceResponse.java
+++ b/src/main/java/com/und/server/auth/dto/NonceResponse.java
@@ -1,11 +1,9 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Response with a Nonce")
 public record NonceResponse(
 	@Schema(description = "A unique and single-use string for security", example = "a1b2c3d4-e5f6-78...")
-	@JsonProperty("nonce") String nonce
+	String nonce
 ) { }

--- a/src/main/java/com/und/server/auth/dto/OidcPublicKey.java
+++ b/src/main/java/com/und/server/auth/dto/OidcPublicKey.java
@@ -1,26 +1,24 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "OIDC Public Key Details")
 public record OidcPublicKey(
 	@Schema(description = "Key ID", example = "a1b2c3d4e5")
-	@JsonProperty("kid") String kid,
+	String kid,
 
 	@Schema(description = "Key Type", example = "RSA")
-	@JsonProperty("kty") String kty,
+	String kty,
 
 	@Schema(description = "Algorithm", example = "RS256")
-	@JsonProperty("alg") String alg,
+	String alg,
 
 	@Schema(description = "Usage", example = "sig")
-	@JsonProperty("use") String use,
+	String use,
 
 	@Schema(description = "Modulus", example = "q8zZ0b_MNaLd6Ny8wd4...")
-	@JsonProperty("n") String n,
+	String n,
 
 	@Schema(description = "Exponent", example = "AQAB")
-	@JsonProperty("e") String e
+	String e
 ) { }

--- a/src/main/java/com/und/server/auth/dto/OidcPublicKeys.java
+++ b/src/main/java/com/und/server/auth/dto/OidcPublicKeys.java
@@ -2,7 +2,6 @@ package com.und.server.auth.dto;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
@@ -11,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "A list of OIDC Public Keys")
 public record OidcPublicKeys(
 	@Schema(description = "List of public keys", example = "[...]")
-	@JsonProperty("keys") List<OidcPublicKey> keys
+	List<OidcPublicKey> keys
 ) {
 	public OidcPublicKey matchingKey(final String kid, final String alg) {
 		return keys.stream()

--- a/src/main/java/com/und/server/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/und/server/auth/dto/RefreshTokenRequest.java
@@ -1,15 +1,13 @@
 package com.und.server.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Request to Reissue Tokens")
 public record RefreshTokenRequest(
 	@Schema(description = "Expired Access Token", example = "eyJhbGciOiJIUzI1Ni...")
-	@NotBlank(message = "Access Token must not be blank") @JsonProperty("access_token") String accessToken,
+	@NotBlank(message = "Access Token must not be blank") String accessToken,
 
 	@Schema(description = "Valid Refresh Token", example = "a1b2c3d4-e5f6-78...")
-	@NotBlank(message = "Refresh Token must not be blank") @JsonProperty("refresh_token") String refreshToken
+	@NotBlank(message = "Refresh Token must not be blank") String refreshToken
 ) { }

--- a/src/main/java/com/und/server/auth/oauth/Provider.java
+++ b/src/main/java/com/und/server/auth/oauth/Provider.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Provider {
 
-	KAKAO("kakao");
+	KAKAO("kakao"),
+	APPLE("apple");
 
 	private final String name;
 

--- a/src/main/java/com/und/server/auth/service/NonceService.java
+++ b/src/main/java/com/und/server/auth/service/NonceService.java
@@ -26,6 +26,9 @@ public class NonceService {
 
 	@Transactional
 	public void validateNonce(final String value, final Provider provider) {
+		validateNonceValue(value);
+		validateProvider(provider);
+
 		nonceRepository.findById(value)
 			.filter(n -> n.getProvider() == provider)
 			.orElseThrow(() -> new ServerException(ServerErrorResult.INVALID_NONCE));
@@ -33,9 +36,11 @@ public class NonceService {
 		nonceRepository.deleteById(value);
 	}
 
-
 	@Transactional
 	public void saveNonce(final String value, final Provider provider) {
+		validateNonceValue(value);
+		validateProvider(provider);
+
 		final Nonce nonce = Nonce.builder()
 			.value(value)
 			.provider(provider)
@@ -44,9 +49,16 @@ public class NonceService {
 		nonceRepository.save(nonce);
 	}
 
-	@Transactional
-	public void deleteNonce(final String value) {
-		nonceRepository.deleteById(value);
+	private void validateNonceValue(final String value) {
+		if (value == null) {
+			throw new ServerException(ServerErrorResult.INVALID_NONCE);
+		}
+	}
+
+	private void validateProvider(final Provider provider) {
+		if (provider == null) {
+			throw new ServerException(ServerErrorResult.INVALID_PROVIDER);
+		}
 	}
 
 }

--- a/src/main/java/com/und/server/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/und/server/auth/service/RefreshTokenService.java
@@ -25,9 +25,12 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void validateRefreshToken(final Long memberId, final String providedToken) {
+		validateMemberIdIsNotNull(memberId);
+		validateTokenValueIsNotNull(providedToken);
+
 		refreshTokenRepository.findById(memberId)
 			.map(RefreshToken::getValue)
-			.filter(savedToken -> savedToken.equals(providedToken))
+			.filter(savedToken -> providedToken.equals(savedToken))
 			.orElseThrow(() -> {
 				deleteRefreshToken(memberId);
 				return new ServerException(ServerErrorResult.INVALID_TOKEN);
@@ -35,10 +38,13 @@ public class RefreshTokenService {
 	}
 
 	@Transactional
-	public void saveRefreshToken(final Long memberId, final String refreshToken) {
+	public void saveRefreshToken(final Long memberId, final String value) {
+		validateMemberIdIsNotNull(memberId);
+		validateTokenValueIsNotNull(value);
+
 		final RefreshToken token = RefreshToken.builder()
 			.memberId(memberId)
-			.value(refreshToken)
+			.value(value)
 			.build();
 
 		refreshTokenRepository.save(token);
@@ -46,6 +52,21 @@ public class RefreshTokenService {
 
 	@Transactional
 	public void deleteRefreshToken(final Long memberId) {
+		validateMemberIdIsNotNull(memberId);
+
 		refreshTokenRepository.deleteById(memberId);
 	}
+
+	private void validateMemberIdIsNotNull(final Long memberId) {
+		if (memberId == null) {
+			throw new ServerException(ServerErrorResult.INVALID_MEMBER_ID);
+		}
+	}
+
+	private void validateTokenValueIsNotNull(final String token) {
+		if (token == null) {
+			throw new ServerException(ServerErrorResult.INVALID_TOKEN);
+		}
+	}
+
 }

--- a/src/main/java/com/und/server/common/controller/TestController.java
+++ b/src/main/java/com/und/server/common/controller/TestController.java
@@ -16,8 +16,6 @@ import com.und.server.auth.filter.AuthMember;
 import com.und.server.auth.service.AuthService;
 import com.und.server.common.dto.TestAuthRequest;
 import com.und.server.common.dto.TestHelloResponse;
-import com.und.server.common.exception.ServerErrorResult;
-import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.MemberResponse;
 import com.und.server.member.entity.Member;
 import com.und.server.member.service.MemberService;
@@ -42,8 +40,7 @@ public class TestController {
 
 	@GetMapping("/hello")
 	public ResponseEntity<TestHelloResponse> greet(@Parameter(hidden = true) @AuthMember final Long memberId) {
-		final Member member = memberService.findMemberById(memberId)
-			.orElseThrow(() -> new ServerException(ServerErrorResult.MEMBER_NOT_FOUND));
+		final Member member = memberService.findMemberById(memberId);
 		final String nickname = member.getNickname() != null ? member.getNickname() : "Member";
 		final TestHelloResponse response = new TestHelloResponse("Hello, " + nickname + "!");
 

--- a/src/main/java/com/und/server/common/dto/ErrorResponse.java
+++ b/src/main/java/com/und/server/common/dto/ErrorResponse.java
@@ -1,16 +1,12 @@
 package com.und.server.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "API Error Response")
 public record ErrorResponse(
 	@Schema(description = "Error Code", example = "UNAUTHORIZED_ACCESS")
-	@JsonProperty("code")
 	String code,
 
 	@Schema(description = "Error Message", example = "Unauthorized Access")
-	@JsonProperty("message")
 	Object message
 ) { }

--- a/src/main/java/com/und/server/common/dto/TestAuthRequest.java
+++ b/src/main/java/com/und/server/common/dto/TestAuthRequest.java
@@ -1,21 +1,19 @@
 package com.und.server.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Request for issuing test tokens")
 public record TestAuthRequest(
 	@Schema(description = "OAuth provider name", example = "kakao")
-	@NotBlank(message = "Provider name must not be blank") @JsonProperty("provider")
+	@NotBlank(message = "Provider name must not be blank")
 	String provider,
 
 	@Schema(description = "Unique ID from the provider", example = "123456789")
-	@NotBlank(message = "Provider ID must not be blank") @JsonProperty("provider_id")
+	@NotBlank(message = "Provider ID must not be blank")
 	String providerId,
 
 	@Schema(description = "User's nickname", example = "Chori")
-	@NotBlank(message = "Nickname must not be blank") @JsonProperty("nickname")
+	@NotBlank(message = "Nickname must not be blank")
 	String nickname
 ) { }

--- a/src/main/java/com/und/server/common/dto/TestHelloResponse.java
+++ b/src/main/java/com/und/server/common/dto/TestHelloResponse.java
@@ -1,12 +1,9 @@
 package com.und.server.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Response for the test hello endpoint")
 public record TestHelloResponse(
 	@Schema(description = "Greeting message", example = "Hello, Chori!")
-	@JsonProperty("message")
 	String message
 ) { }

--- a/src/main/java/com/und/server/common/exception/ServerErrorResult.java
+++ b/src/main/java/com/und/server/common/exception/ServerErrorResult.java
@@ -12,6 +12,7 @@ public enum ServerErrorResult {
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid Parameter"),
 	INVALID_NONCE(HttpStatus.BAD_REQUEST, "Invalid nonce"),
 	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "Invalid Provider"),
+	INVALID_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Invalid Provider ID"),
 	PUBLIC_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "Public Key Not Found"),
 	INVALID_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "Invalid Public Key"),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired Token"),
@@ -22,8 +23,8 @@ public enum ServerErrorResult {
 	WEAK_TOKEN_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "Token Key is Weak"),
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "Invalid Token"),
 	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "Unauthorized Access"),
-	// FIXME: Remove MEMBER_NOT_FOUND when deleting TestController
-	MEMBER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Member Not Found"),
+	INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "Invalid Member ID"),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member Not Found"),
 	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/und/server/member/controller/MemberController.java
+++ b/src/main/java/com/und/server/member/controller/MemberController.java
@@ -3,13 +3,18 @@ package com.und.server.member.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.und.server.auth.filter.AuthMember;
+import com.und.server.member.dto.MemberResponse;
+import com.und.server.member.dto.NicknameRequest;
 import com.und.server.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -18,6 +23,16 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
 	private final MemberService memberService;
+
+	@PatchMapping("/member/nickname")
+	public ResponseEntity<MemberResponse> updateNickname(
+		@Parameter(hidden = true) @AuthMember final Long memberId,
+		@RequestBody @Valid final NicknameRequest nicknameRequest
+	) {
+		final MemberResponse memberResponse = memberService.updateNickname(memberId, nicknameRequest);
+
+		return ResponseEntity.status(HttpStatus.OK).body(memberResponse);
+	}
 
 	@DeleteMapping("/member")
 	public ResponseEntity<Void> deleteMember(@Parameter(hidden = true) @AuthMember final Long memberId) {

--- a/src/main/java/com/und/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/und/server/member/dto/MemberResponse.java
@@ -2,7 +2,6 @@ package com.und.server.member.dto;
 
 import java.time.LocalDateTime;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.und.server.member.entity.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,19 +9,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Member Response DTO")
 public record MemberResponse(
 	@Schema(description = "Member ID", example = "1")
-	@JsonProperty("id") Long id,
+	Long id,
 
 	@Schema(description = "Member's nickname", example = "Chori")
-	@JsonProperty("nickname") String nickname,
+	String nickname,
 
 	@Schema(description = "Kakao ID", example = "1234567890")
-	@JsonProperty("kakao_id") String kakaoId,
+	String kakaoId,
 
 	@Schema(description = "Creation timestamp of the member", example = "2025-07-31T22:27:36.037717")
-	@JsonProperty("created_at") LocalDateTime createdAt,
+	LocalDateTime createdAt,
 
 	@Schema(description = "Last update timestamp of the member", example = "2025-07-31T22:27:36.037744")
-	@JsonProperty("updated_at") LocalDateTime updatedAt
+	LocalDateTime updatedAt
 ) {
 	public static MemberResponse from(final Member member) {
 		return new MemberResponse(

--- a/src/main/java/com/und/server/member/dto/NicknameRequest.java
+++ b/src/main/java/com/und/server/member/dto/NicknameRequest.java
@@ -1,0 +1,10 @@
+package com.und.server.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Nickname Request DTO")
+public record NicknameRequest(
+	@Schema(description = "Member's nickname", example = "Chori")
+	@NotBlank(message = "Nickname must not be blank") String nickname
+) { }

--- a/src/main/java/com/und/server/member/entity/Member.java
+++ b/src/main/java/com/und/server/member/entity/Member.java
@@ -43,4 +43,8 @@ public class Member {
 	@Column
 	private LocalDateTime updatedAt;
 
+	public void updateNickname(final String nickname) {
+		this.nickname = nickname;
+	}
+
 }

--- a/src/test/java/com/und/server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/und/server/auth/controller/AuthControllerTest.java
@@ -5,12 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,9 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -375,15 +370,9 @@ class AuthControllerTest {
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
-		final Authentication auth = new UsernamePasswordAuthenticationToken(
-			memberId,
-			null,
-			Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
-		);
-
 		// when
 		final ResultActions resultActions = mockMvc.perform(
-			MockMvcRequestBuilders.delete(url).with(authentication(auth))
+			MockMvcRequestBuilders.delete(url)
 		);
 
 		// then

--- a/src/test/java/com/und/server/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/und/server/auth/service/RefreshTokenServiceTest.java
@@ -63,6 +63,58 @@ class RefreshTokenServiceTest {
 	}
 
 	@Test
+	@DisplayName("Throws an exception when saving a null token")
+	void Given_NullToken_When_SaveRefreshToken_Then_ThrowsException() {
+		// when
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.saveRefreshToken(memberId, null));
+
+		// then
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+	}
+
+	@Test
+	@DisplayName("Throws an exception when validating with a null token")
+	void Given_NullToken_When_ValidateRefreshToken_Then_ThrowsException() {
+		// when
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.validateRefreshToken(memberId, null));
+
+		// then
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+	}
+
+	@Test
+	@DisplayName("Throws an exception when saving a refresh token with a null member ID")
+	void Given_NullMemberId_When_SaveRefreshToken_Then_ThrowsException() {
+		// when & then
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.saveRefreshToken(null, refreshTokenValue));
+
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+	}
+
+	@Test
+	@DisplayName("Throws an exception when validating a refresh token with a null member ID")
+	void Given_NullMemberId_When_ValidateRefreshToken_Then_ThrowsException() {
+		// when & then
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.validateRefreshToken(null, refreshTokenValue));
+
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+	}
+
+	@Test
+	@DisplayName("Throws an exception when deleting a refresh token with a null member ID")
+	void Given_NullMemberId_When_DeleteRefreshToken_Then_ThrowsException() {
+		// when & then
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.deleteRefreshToken(null));
+
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+	}
+
+	@Test
 	@DisplayName("Succeeds validation if the provided token matches the stored one")
 	void Given_MatchingToken_When_ValidateRefreshToken_Then_Succeeds() {
 		// given
@@ -89,6 +141,25 @@ class RefreshTokenServiceTest {
 		// when
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> refreshTokenService.validateRefreshToken(memberId, "wrong-token"));
+
+		// then
+		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		verify(refreshTokenRepository).deleteById(memberId);
+	}
+
+	@Test
+	@DisplayName("Throws an exception if the stored token value is null")
+	void Given_StoredTokenWithValueNull_When_ValidateRefreshToken_Then_ThrowsException() {
+		// given
+		final RefreshToken savedTokenWithNullValue = RefreshToken.builder()
+			.memberId(memberId)
+			.value(null)
+			.build();
+		doReturn(Optional.of(savedTokenWithNullValue)).when(refreshTokenRepository).findById(memberId);
+
+		// when
+		final ServerException exception = assertThrows(ServerException.class,
+			() -> refreshTokenService.validateRefreshToken(memberId, refreshTokenValue));
 
 		// then
 		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);

--- a/src/test/java/com/und/server/common/controller/TestControllerTest.java
+++ b/src/test/java/com/und/server/common/controller/TestControllerTest.java
@@ -4,13 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -135,25 +131,23 @@ class TestControllerTest {
 	}
 
 	@Test
-	@DisplayName("Fails to greet and returns unauthorized when the authenticated member is not found")
-	void Given_AuthenticatedUserNotFoundInDb_When_Greet_Then_ReturnsUnauthorized() throws Exception {
+	@DisplayName("Fails to greet and returns not found when the authenticated member is not found")
+	void Given_AuthenticatedUserNotFoundInDb_When_Greet_Then_ReturnsNotFound() throws Exception {
 		// given
 		final String url = "/v1/test/hello";
 		final Long memberId = 3L;
 
-		doReturn(Optional.empty()).when(memberService).findMemberById(memberId);
+		doThrow(new ServerException(ServerErrorResult.MEMBER_NOT_FOUND)).when(memberService).findMemberById(memberId);
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
-		final Authentication auth = new UsernamePasswordAuthenticationToken(memberId, null);
-
 		// when
 		final ResultActions result = mockMvc.perform(
-			MockMvcRequestBuilders.get(url).with(authentication(auth))
+			MockMvcRequestBuilders.get(url)
 		);
 
 		// then
-		result.andExpect(status().isUnauthorized())
+		result.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value(ServerErrorResult.MEMBER_NOT_FOUND.name()))
 			.andExpect(jsonPath("$.message").value(ServerErrorResult.MEMBER_NOT_FOUND.getMessage()));
 	}
@@ -188,15 +182,13 @@ class TestControllerTest {
 		final Long memberId = 1L;
 		final Member member = Member.builder().id(memberId).nickname("Chori").build();
 
-		doReturn(Optional.of(member)).when(memberService).findMemberById(memberId);
+		doReturn(member).when(memberService).findMemberById(memberId);
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
-		final Authentication auth = new UsernamePasswordAuthenticationToken(memberId, null);
-
 		// when
 		final ResultActions result = mockMvc.perform(
-			MockMvcRequestBuilders.get(url).with(authentication(auth))
+			MockMvcRequestBuilders.get(url)
 		);
 
 		// then
@@ -212,15 +204,13 @@ class TestControllerTest {
 		final Long memberId = 2L;
 		final Member member = Member.builder().id(memberId).nickname(null).build();
 
-		doReturn(Optional.of(member)).when(memberService).findMemberById(memberId);
+		doReturn(member).when(memberService).findMemberById(memberId);
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
-		final Authentication auth = new UsernamePasswordAuthenticationToken(memberId, null);
-
 		// when
 		final ResultActions result = mockMvc.perform(
-			MockMvcRequestBuilders.get(url).with(authentication(auth))
+			MockMvcRequestBuilders.get(url)
 		);
 
 		// then

--- a/src/test/java/com/und/server/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/und/server/member/controller/MemberControllerTest.java
@@ -3,13 +3,9 @@ package com.und.server.member.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,18 +14,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.und.server.auth.filter.AuthMemberArgumentResolver;
 import com.und.server.common.exception.GlobalExceptionHandler;
 import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
+import com.und.server.member.dto.MemberResponse;
+import com.und.server.member.dto.NicknameRequest;
 import com.und.server.member.service.MemberService;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +42,7 @@ class MemberControllerTest {
 	private AuthMemberArgumentResolver authMemberArgumentResolver;
 
 	private MockMvc mockMvc;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@BeforeEach
 	void init() {
@@ -55,7 +53,85 @@ class MemberControllerTest {
 	}
 
 	@Test
-	@DisplayName("Fails member deletion and returns unauthorized when user is not authenticated")
+	@DisplayName("Fails to update nickname with bad request when nickname is null")
+	void Given_NullNickname_When_UpdateNickname_Then_ReturnsBadRequest() throws Exception {
+		// given
+		final String url = "/v1/member/nickname";
+		final NicknameRequest request = new NicknameRequest(null);
+		final String requestBody = objectMapper.writeValueAsString(request);
+		final Long memberId = 1L;
+
+		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
+		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.patch(url)
+				.content(requestBody)
+				.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.message[0]").value("Nickname must not be blank"));
+	}
+
+	@Test
+	@DisplayName("Fails to update nickname and returns unauthorized when user is not authenticated")
+	void Given_UnauthenticatedUser_When_UpdateNickname_Then_ReturnsUnauthorized() throws Exception {
+		// given
+		final String url = "/v1/member/nickname";
+		final NicknameRequest request = new NicknameRequest("new-nickname");
+		final String requestBody = objectMapper.writeValueAsString(request);
+		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+
+		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
+		doThrow(new ServerException(errorResult))
+			.when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.patch(url)
+				.content(requestBody)
+				.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(errorResult.name()))
+			.andExpect(jsonPath("$.message").value(errorResult.getMessage()));
+	}
+
+	@Test
+	@DisplayName("Succeeds in updating nickname for an authenticated user")
+	void Given_AuthenticatedUser_When_UpdateNickname_Then_ReturnsOkWithUpdatedInfo() throws Exception {
+		// given
+		final String url = "/v1/member/nickname";
+		final Long memberId = 1L;
+		final String newNickname = "new-nickname";
+		final NicknameRequest request = new NicknameRequest(newNickname);
+		final MemberResponse response = new MemberResponse(memberId, newNickname, null, null, null);
+
+		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
+		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
+		doReturn(response).when(memberService).updateNickname(memberId, request);
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.patch(url)
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(memberId))
+			.andExpect(jsonPath("$.nickname").value(newNickname));
+	}
+
+	@Test
+	@DisplayName("Fails to delete member and returns unauthorized when user is not authenticated")
 	void Given_UnauthenticatedUser_When_DeleteMember_Then_ReturnsUnauthorized() throws Exception {
 		// given
 		final String url = "/v1/member";
@@ -74,13 +150,11 @@ class MemberControllerTest {
 		resultActions.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(errorResult.name()))
 			.andExpect(jsonPath("$.message").value(errorResult.getMessage()));
-
-		verify(memberService, never()).deleteMemberById(any(Long.class));
 	}
 
 	@Test
-	@DisplayName("Succeeds in deleting the member and returns no content")
-	void Given_MemberId_When_DeleteMember_Then_ReturnsNoContent() throws Exception {
+	@DisplayName("Succeeds in deleting member for an authenticated user")
+	void Given_AuthenticatedUser_When_DeleteMember_Then_ReturnsNoContent() throws Exception {
 		// given
 		final String url = "/v1/member";
 		final Long memberId = 1L;
@@ -88,17 +162,13 @@ class MemberControllerTest {
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
-		final Authentication auth = new UsernamePasswordAuthenticationToken(
-			memberId,
-			null,
-			Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.delete(url)
 		);
 
-		// when & then
-		mockMvc.perform(
-			MockMvcRequestBuilders.delete(url).with(authentication(auth))
-		).andExpect(status().isNoContent());
-
+		// then
+		resultActions.andExpect(status().isNoContent());
 		verify(memberService).deleteMemberById(memberId);
 	}
 


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] feat: 새로운 기능 추가

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
feat/nickname -> dev

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
사용자가 닉네임을 변경하기 위한 API를 구현했습니다.
닉네임 변경 프로세스는 다음과 같습니다.
1. 로그인한 사용자로부터 닉네임 변경 요청을 PATCH method로 받습니다. 이때 클라이언트는 어떤 닉네임으로 변경할 것인지  NicknameRequest에 담아 서버에 보냅니다.
2. 서버는 Authorization 헤더에서 사용자의 Member ID 정보와 NicknameRequest에 담긴 정보를 확인합니다.
3. Member ID로 DB에서 사용자를 조회하고 닉네임을 변경합니다.
4. 서버는 변경된 사용자 정보를 MemberResponse에 담아 클라이언트로 전송합니다.

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="1465" height="272" alt="Screenshot 2025-08-01 at 3 54 17 PM" src="https://github.com/user-attachments/assets/d13eba6b-80c5-4806-9d18-dcdc54407ba6" />

### 📂 관련 이슈
<!-- 예) #5 -->
#76 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
닉네임 변경 API를 구현했습니다.
추가로 DTO에 있는 JsonProperty를 제거했으며 null 안정성을 위해 MemberService, NonceService, RefreshTokenService에 파라미터 검증을 추가했습니다.