### PR TITLE
Separate exceptions by domain

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -27,7 +27,8 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ jacocoTestCoverageVerification {
 			limit {
 				counter = 'BRANCH'
 				value = 'COVEREDRATIO'
-				minimum = 0.50
+				minimum = 0.70
 			}
 
 			// Maximum number of lines in a file

--- a/src/main/java/com/und/server/auth/controller/AuthController.java
+++ b/src/main/java/com/und/server/auth/controller/AuthController.java
@@ -17,6 +17,7 @@ import com.und.server.auth.filter.AuthMember;
 import com.und.server.auth.service.AuthService;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -51,8 +52,10 @@ public class AuthController {
 	}
 
 	@DeleteMapping("/logout")
+	@ApiResponse(responseCode = "204", description = "Logout successful")
 	public ResponseEntity<Void> logout(@Parameter(hidden = true) @AuthMember final Long memberId) {
 		authService.logout(memberId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
+
 }

--- a/src/main/java/com/und/server/auth/dto/OidcPublicKeys.java
+++ b/src/main/java/com/und/server/auth/dto/OidcPublicKeys.java
@@ -2,7 +2,7 @@ package com.und.server.auth.dto;
 
 import java.util.List;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +16,6 @@ public record OidcPublicKeys(
 		return keys.stream()
 			.filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
 			.findAny()
-			.orElseThrow(() -> new ServerException(ServerErrorResult.PUBLIC_KEY_NOT_FOUND));
+			.orElseThrow(() -> new ServerException(AuthErrorResult.PUBLIC_KEY_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/und/server/auth/exception/AuthErrorResult.java
+++ b/src/main/java/com/und/server/auth/exception/AuthErrorResult.java
@@ -1,15 +1,16 @@
-package com.und.server.common.exception;
+package com.und.server.auth.exception;
 
 import org.springframework.http.HttpStatus;
+
+import com.und.server.common.exception.ErrorResult;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ServerErrorResult implements ErrorResult {
+public enum AuthErrorResult implements ErrorResult {
 
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid Parameter"),
 	INVALID_NONCE(HttpStatus.BAD_REQUEST, "Invalid nonce"),
 	INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "Invalid Provider"),
 	INVALID_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Invalid Provider ID"),
@@ -22,10 +23,7 @@ public enum ServerErrorResult implements ErrorResult {
 	UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST, "Unsupported Token"),
 	WEAK_TOKEN_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "Token Key is Weak"),
 	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "Invalid Token"),
-	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "Unauthorized Access"),
-	INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "Invalid Member ID"),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member Not Found"),
-	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception");
+	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "Unauthorized Access");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/und/server/auth/filter/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/und/server/auth/filter/AuthMemberArgumentResolver.java
@@ -9,7 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @Component
@@ -26,7 +26,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
 		final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
 		final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication == null || !(authentication.getPrincipal() instanceof final Long memberId)) {
-			throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS);
+			throw new ServerException(AuthErrorResult.UNAUTHORIZED_ACCESS);
 		}
 		return memberId;
 	}

--- a/src/main/java/com/und/server/auth/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/und/server/auth/filter/CustomAuthenticationEntryPoint.java
@@ -6,7 +6,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,6 +24,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 		final HttpServletResponse response,
 		final AuthenticationException authException
 	) throws IOException {
-		errorResponseWriter.sendErrorResponse(response, ServerErrorResult.UNAUTHORIZED_ACCESS);
+		errorResponseWriter.sendErrorResponse(response, AuthErrorResult.UNAUTHORIZED_ACCESS);
 	}
 }

--- a/src/main/java/com/und/server/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/und/server/auth/filter/JwtAuthenticationFilter.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.jwt.JwtProvider;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
 import jakarta.servlet.FilterChain;
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 					pattern -> pathMatcher.match(pattern, request.getServletPath())
 				);
 
-				if (e.getErrorResult() != ServerErrorResult.EXPIRED_TOKEN || !isPermissivePath) {
+				if (e.getErrorResult() != AuthErrorResult.EXPIRED_TOKEN || !isPermissivePath) {
 					errorResponseWriter.sendErrorResponse(response, e.getErrorResult());
 					return;
 				}

--- a/src/main/java/com/und/server/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/und/server/auth/jwt/JwtProvider.java
@@ -138,18 +138,16 @@ public class JwtProvider {
 			// For non-production environments, provide detailed error messages.
 			if (e instanceof MalformedJwtException) {
 				throw new ServerException(AuthErrorResult.MALFORMED_TOKEN, e);
-			}
-			if (e instanceof UnsupportedJwtException) {
+			} else if (e instanceof UnsupportedJwtException) {
 				throw new ServerException(AuthErrorResult.UNSUPPORTED_TOKEN, e);
-			}
-			if (e instanceof WeakKeyException) {
+			} else if (e instanceof WeakKeyException) {
 				throw new ServerException(AuthErrorResult.WEAK_TOKEN_KEY, e);
-			}
-			if (e instanceof SignatureException) {
+			} else if (e instanceof SignatureException) {
 				throw new ServerException(AuthErrorResult.INVALID_TOKEN_SIGNATURE, e);
+			} else {
+				// Fallback for any other JWT-related exceptions.
+				throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 			}
-			// Fallback for any other JWT-related exceptions.
-			throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 		}
 	}
 

--- a/src/main/java/com/und/server/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/und/server/auth/jwt/JwtProvider.java
@@ -16,8 +16,8 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.IdTokenPayload;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.common.util.ProfileManager;
 
@@ -45,7 +45,7 @@ public class JwtProvider {
 			final String decodedHeader = decodeBase64UrlPart(token.split("\\.")[0]);
 			return new ObjectMapper().readValue(decodedHeader, new TypeReference<>() { });
 		} catch (final Exception e) {
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN, e);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 		}
 	}
 
@@ -55,7 +55,7 @@ public class JwtProvider {
 			final Map<String, Object> claims = new ObjectMapper().readValue(payloadJson, new TypeReference<>() { });
 			return (String) claims.get("nonce");
 		} catch (final Exception e) {
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN, e);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 		}
 	}
 
@@ -107,7 +107,7 @@ public class JwtProvider {
 		try {
 			return parseToken(token, builder);
 		} catch (final ExpiredJwtException e) {
-			throw new ServerException(ServerErrorResult.EXPIRED_TOKEN, e);
+			throw new ServerException(AuthErrorResult.EXPIRED_TOKEN, e);
 		}
 	}
 
@@ -132,24 +132,24 @@ public class JwtProvider {
 		} catch (final JwtException e) {
 			// For prod or stg environments, return a generic error to avoid leaking details.
 			if (profileManager.isProdOrStgProfile()) {
-				throw new ServerException(ServerErrorResult.UNAUTHORIZED_ACCESS, e);
+				throw new ServerException(AuthErrorResult.UNAUTHORIZED_ACCESS, e);
 			}
 
 			// For non-production environments, provide detailed error messages.
 			if (e instanceof MalformedJwtException) {
-				throw new ServerException(ServerErrorResult.MALFORMED_TOKEN, e);
+				throw new ServerException(AuthErrorResult.MALFORMED_TOKEN, e);
 			}
 			if (e instanceof UnsupportedJwtException) {
-				throw new ServerException(ServerErrorResult.UNSUPPORTED_TOKEN, e);
+				throw new ServerException(AuthErrorResult.UNSUPPORTED_TOKEN, e);
 			}
 			if (e instanceof WeakKeyException) {
-				throw new ServerException(ServerErrorResult.WEAK_TOKEN_KEY, e);
+				throw new ServerException(AuthErrorResult.WEAK_TOKEN_KEY, e);
 			}
 			if (e instanceof SignatureException) {
-				throw new ServerException(ServerErrorResult.INVALID_TOKEN_SIGNATURE, e);
+				throw new ServerException(AuthErrorResult.INVALID_TOKEN_SIGNATURE, e);
 			}
 			// Fallback for any other JWT-related exceptions.
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN, e);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 		}
 	}
 
@@ -172,14 +172,14 @@ public class JwtProvider {
 			return Long.valueOf(subject);
 		} catch (final NumberFormatException e) {
 			// The subject was not a valid Long, which is unexpected for our tokens.
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN, e);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN, e);
 		}
 	}
 
 	private String getValidSubject(final Claims claims) {
 		final String subject = claims.getSubject();
 		if (subject == null) {
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN);
 		}
 		return subject;
 	}

--- a/src/main/java/com/und/server/auth/oauth/OidcClientFactory.java
+++ b/src/main/java/com/und/server/auth/oauth/OidcClientFactory.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @Component
@@ -21,7 +21,7 @@ public class OidcClientFactory {
 
 	public OidcClient getOidcClient(final Provider provider) {
 		return Optional.ofNullable(oidcClients.get(provider))
-			.orElseThrow(() -> new ServerException(ServerErrorResult.INVALID_PROVIDER));
+			.orElseThrow(() -> new ServerException(AuthErrorResult.INVALID_PROVIDER));
 	}
 
 }

--- a/src/main/java/com/und/server/auth/oauth/OidcProviderFactory.java
+++ b/src/main/java/com/und/server/auth/oauth/OidcProviderFactory.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import com.und.server.auth.dto.OidcPublicKeys;
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @Component
@@ -30,7 +30,7 @@ public class OidcProviderFactory {
 
 	private OidcProvider getOidcProvider(final Provider provider) {
 		return Optional.ofNullable(oidcProviders.get(provider))
-			.orElseThrow(() -> new ServerException(ServerErrorResult.INVALID_PROVIDER));
+			.orElseThrow(() -> new ServerException(AuthErrorResult.INVALID_PROVIDER));
 	}
 
 }

--- a/src/main/java/com/und/server/auth/oauth/PublicKeyProvider.java
+++ b/src/main/java/com/und/server/auth/oauth/PublicKeyProvider.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.und.server.auth.dto.OidcPublicKey;
 import com.und.server.auth.dto.OidcPublicKeys;
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @Component
@@ -37,7 +37,7 @@ public class PublicKeyProvider {
 
 			return KeyFactory.getInstance(matchingKey.kty()).generatePublic(publicKeySpec);
 		} catch (final IllegalArgumentException | NoSuchAlgorithmException | InvalidKeySpecException e) {
-			throw new ServerException(ServerErrorResult.INVALID_PUBLIC_KEY, e);
+			throw new ServerException(AuthErrorResult.INVALID_PUBLIC_KEY, e);
 		}
 	}
 

--- a/src/main/java/com/und/server/auth/service/NonceService.java
+++ b/src/main/java/com/und/server/auth/service/NonceService.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.und.server.auth.entity.Nonce;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.Provider;
 import com.und.server.auth.repository.NonceRepository;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class NonceService {
 
 		nonceRepository.findById(value)
 			.filter(n -> n.getProvider() == provider)
-			.orElseThrow(() -> new ServerException(ServerErrorResult.INVALID_NONCE));
+			.orElseThrow(() -> new ServerException(AuthErrorResult.INVALID_NONCE));
 
 		nonceRepository.deleteById(value);
 	}
@@ -51,13 +51,13 @@ public class NonceService {
 
 	private void validateNonceValue(final String value) {
 		if (value == null) {
-			throw new ServerException(ServerErrorResult.INVALID_NONCE);
+			throw new ServerException(AuthErrorResult.INVALID_NONCE);
 		}
 	}
 
 	private void validateProvider(final Provider provider) {
 		if (provider == null) {
-			throw new ServerException(ServerErrorResult.INVALID_PROVIDER);
+			throw new ServerException(AuthErrorResult.INVALID_PROVIDER);
 		}
 	}
 

--- a/src/main/java/com/und/server/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/und/server/auth/service/RefreshTokenService.java
@@ -6,9 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.und.server.auth.entity.RefreshToken;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.repository.RefreshTokenRepository;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
+import com.und.server.member.exception.MemberErrorResult;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,7 +34,7 @@ public class RefreshTokenService {
 			.filter(savedToken -> providedToken.equals(savedToken))
 			.orElseThrow(() -> {
 				deleteRefreshToken(memberId);
-				return new ServerException(ServerErrorResult.INVALID_TOKEN);
+				return new ServerException(AuthErrorResult.INVALID_TOKEN);
 			});
 	}
 
@@ -59,13 +60,13 @@ public class RefreshTokenService {
 
 	private void validateMemberIdIsNotNull(final Long memberId) {
 		if (memberId == null) {
-			throw new ServerException(ServerErrorResult.INVALID_MEMBER_ID);
+			throw new ServerException(MemberErrorResult.INVALID_MEMBER_ID);
 		}
 	}
 
 	private void validateTokenValueIsNotNull(final String token) {
 		if (token == null) {
-			throw new ServerException(ServerErrorResult.INVALID_TOKEN);
+			throw new ServerException(AuthErrorResult.INVALID_TOKEN);
 		}
 	}
 

--- a/src/main/java/com/und/server/common/exception/CommonErrorResult.java
+++ b/src/main/java/com/und/server/common/exception/CommonErrorResult.java
@@ -1,0 +1,18 @@
+package com.und.server.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorResult implements ErrorResult {
+
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid Parameter"),
+	UNKNOWN_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "Unknown Exception");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}

--- a/src/main/java/com/und/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/und/server/common/exception/GlobalExceptionHandler.java
@@ -41,7 +41,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 			.toList();
 
 		log.warn("Invalid DTO Parameter Errors: {}", errorList);
-		return this.buildErrorResponse(ServerErrorResult.INVALID_PARAMETER, errorList);
+		return this.buildErrorResponse(CommonErrorResult.INVALID_PARAMETER, errorList);
 	}
 
 	@ExceptionHandler({ServerException.class})
@@ -60,8 +60,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		log.warn("Exception occur: ", exception);
 
 		return this.buildErrorResponse(
-			ServerErrorResult.UNKNOWN_EXCEPTION,
-			ServerErrorResult.UNKNOWN_EXCEPTION.getMessage()
+			CommonErrorResult.UNKNOWN_EXCEPTION,
+			CommonErrorResult.UNKNOWN_EXCEPTION.getMessage()
 		);
 	}
 

--- a/src/main/java/com/und/server/member/controller/MemberController.java
+++ b/src/main/java/com/und/server/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.und.server.member.dto.NicknameRequest;
 import com.und.server.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -35,6 +36,7 @@ public class MemberController {
 	}
 
 	@DeleteMapping("/member")
+	@ApiResponse(responseCode = "204", description = "Delete member successful")
 	public ResponseEntity<Void> deleteMember(@Parameter(hidden = true) @AuthMember final Long memberId) {
 		memberService.deleteMemberById(memberId);
 

--- a/src/main/java/com/und/server/member/exception/MemberErrorResult.java
+++ b/src/main/java/com/und/server/member/exception/MemberErrorResult.java
@@ -1,0 +1,20 @@
+package com.und.server.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.und.server.common.exception.ErrorResult;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorResult implements ErrorResult {
+
+	INVALID_MEMBER_ID(HttpStatus.BAD_REQUEST, "Invalid Member ID"),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member Not Found");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}

--- a/src/main/java/com/und/server/member/service/MemberService.java
+++ b/src/main/java/com/und/server/member/service/MemberService.java
@@ -6,14 +6,15 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.IdTokenPayload;
 import com.und.server.auth.oauth.Provider;
 import com.und.server.auth.service.RefreshTokenService;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.MemberResponse;
 import com.und.server.member.dto.NicknameRequest;
 import com.und.server.member.entity.Member;
+import com.und.server.member.exception.MemberErrorResult;
 import com.und.server.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -46,14 +47,14 @@ public class MemberService {
 		validateMemberIdIsNotNull(memberId);
 
 		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new ServerException(ServerErrorResult.MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new ServerException(MemberErrorResult.MEMBER_NOT_FOUND));
 	}
 
 	public void validateMemberExists(final Long memberId) {
 		validateMemberIdIsNotNull(memberId);
 
 		if (!memberRepository.existsById(memberId)) {
-			throw new ServerException(ServerErrorResult.MEMBER_NOT_FOUND);
+			throw new ServerException(MemberErrorResult.MEMBER_NOT_FOUND);
 		}
 	}
 
@@ -76,7 +77,7 @@ public class MemberService {
 	private Optional<Member> findMemberByProviderId(final Provider provider, final String providerId) {
 		return switch (provider) {
 			case KAKAO -> memberRepository.findByKakaoId(providerId);
-			default -> throw new ServerException(ServerErrorResult.INVALID_PROVIDER);
+			default -> throw new ServerException(AuthErrorResult.INVALID_PROVIDER);
 		};
 	}
 
@@ -84,7 +85,7 @@ public class MemberService {
 		final Member.MemberBuilder memberBuilder = Member.builder().nickname(nickname);
 		switch (provider) {
 			case KAKAO -> memberBuilder.kakaoId(providerId);
-			default -> throw new ServerException(ServerErrorResult.INVALID_PROVIDER);
+			default -> throw new ServerException(AuthErrorResult.INVALID_PROVIDER);
 		}
 
 		return memberRepository.save(memberBuilder.build());
@@ -92,19 +93,19 @@ public class MemberService {
 
 	private void validateMemberIdIsNotNull(final Long memberId) {
 		if (memberId == null) {
-			throw new ServerException(ServerErrorResult.INVALID_MEMBER_ID);
+			throw new ServerException(MemberErrorResult.INVALID_MEMBER_ID);
 		}
 	}
 
 	private void validateProviderIsNotNull(final Provider provider) {
 		if (provider == null) {
-			throw new ServerException(ServerErrorResult.INVALID_PROVIDER);
+			throw new ServerException(AuthErrorResult.INVALID_PROVIDER);
 		}
 	}
 
 	private void validateProviderIdIsNotNull(final String providerId) {
 		if (providerId == null) {
-			throw new ServerException(ServerErrorResult.INVALID_PROVIDER_ID);
+			throw new ServerException(AuthErrorResult.INVALID_PROVIDER_ID);
 		}
 	}
 

--- a/src/test/java/com/und/server/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/und/server/auth/controller/AuthControllerTest.java
@@ -29,10 +29,11 @@ import com.und.server.auth.dto.AuthResponse;
 import com.und.server.auth.dto.NonceRequest;
 import com.und.server.auth.dto.NonceResponse;
 import com.und.server.auth.dto.RefreshTokenRequest;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.filter.AuthMemberArgumentResolver;
 import com.und.server.auth.service.AuthService;
+import com.und.server.common.exception.CommonErrorResult;
 import com.und.server.common.exception.GlobalExceptionHandler;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,7 +76,7 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("Provider name must not be blank"));
 	}
 
@@ -86,7 +87,7 @@ class AuthControllerTest {
 		final String url = "/v1/auth/nonce";
 		final NonceRequest request = new NonceRequest("facebook");
 		final String requestBody = objectMapper.writeValueAsString(request);
-		final ServerErrorResult errorResult = ServerErrorResult.INVALID_PROVIDER;
+		final AuthErrorResult errorResult = AuthErrorResult.INVALID_PROVIDER;
 
 		doThrow(new ServerException(errorResult))
 			.when(authService).handshake(request);
@@ -143,7 +144,7 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("Provider name must not be blank"));
 	}
 
@@ -164,7 +165,7 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("ID Token must not be blank"));
 	}
 
@@ -175,7 +176,7 @@ class AuthControllerTest {
 		final String url = "/v1/auth/login";
 		final AuthRequest request = new AuthRequest("facebook", "dummy.id.token");
 		final String requestBody = objectMapper.writeValueAsString(request);
-		final ServerErrorResult errorResult = ServerErrorResult.INVALID_PROVIDER;
+		final AuthErrorResult errorResult = AuthErrorResult.INVALID_PROVIDER;
 
 		doThrow(new ServerException(errorResult))
 			.when(authService).login(request);
@@ -200,7 +201,7 @@ class AuthControllerTest {
 		final String url = "/v1/auth/login";
 		final AuthRequest request = new AuthRequest("kakao", "dummy.id.token");
 		final String requestBody = objectMapper.writeValueAsString(request);
-		final ServerErrorResult errorResult = ServerErrorResult.UNKNOWN_EXCEPTION;
+		final CommonErrorResult errorResult = CommonErrorResult.UNKNOWN_EXCEPTION;
 
 		doThrow(new RuntimeException("A wild unexpected error appeared!"))
 			.when(authService).login(request);
@@ -274,7 +275,7 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("Access Token must not be blank"));
 	}
 
@@ -295,7 +296,7 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("Refresh Token must not be blank"));
 	}
 
@@ -343,7 +344,7 @@ class AuthControllerTest {
 	void Given_UnauthenticatedUser_When_Logout_Then_ReturnsUnauthorized() throws Exception {
 		// given
 		final String url = "/v1/auth/logout";
-		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doThrow(new ServerException(errorResult))

--- a/src/test/java/com/und/server/auth/dto/OidcPublicKeysTest.java
+++ b/src/test/java/com/und/server/auth/dto/OidcPublicKeysTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 class OidcPublicKeysTest {
@@ -23,7 +23,7 @@ class OidcPublicKeysTest {
 		// when & then
 		assertThatThrownBy(() -> oidcPublicKeys.matchingKey("kid3", "RS256"))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.PUBLIC_KEY_NOT_FOUND);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.PUBLIC_KEY_NOT_FOUND);
 	}
 
 	@Test
@@ -36,7 +36,7 @@ class OidcPublicKeysTest {
 		// when & then
 		assertThatThrownBy(() -> oidcPublicKeys.matchingKey("kid1", "RS512"))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.PUBLIC_KEY_NOT_FOUND);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.PUBLIC_KEY_NOT_FOUND);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/filter/AuthMemberArgumentResolverTest.java
+++ b/src/test/java/com/und/server/auth/filter/AuthMemberArgumentResolverTest.java
@@ -16,7 +16,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,7 +86,7 @@ class AuthMemberArgumentResolverTest {
 		// when & then
 		assertThatThrownBy(() -> authMemberArgumentResolver.resolveArgument(parameter, null, null, null))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.UNAUTHORIZED_ACCESS);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.UNAUTHORIZED_ACCESS);
 	}
 
 	@Test
@@ -101,7 +101,7 @@ class AuthMemberArgumentResolverTest {
 		// when & then
 		assertThatThrownBy(() -> authMemberArgumentResolver.resolveArgument(parameter, null, null, null))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.UNAUTHORIZED_ACCESS);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.UNAUTHORIZED_ACCESS);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/filter/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/und/server/auth/filter/CustomAuthenticationEntryPointTest.java
@@ -10,8 +10,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.dto.ErrorResponse;
-import com.und.server.common.exception.ServerErrorResult;
 
 class CustomAuthenticationEntryPointTest {
 
@@ -30,7 +30,7 @@ class CustomAuthenticationEntryPointTest {
 		final MockHttpServletRequest request = new MockHttpServletRequest();
 		final MockHttpServletResponse response = new MockHttpServletResponse();
 		final AuthenticationException authException = mock(AuthenticationException.class);
-		final ServerErrorResult expectedError = ServerErrorResult.UNAUTHORIZED_ACCESS;
+		final AuthErrorResult expectedError = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		// when
 		customAuthenticationEntryPoint.commence(request, response, authException);

--- a/src/test/java/com/und/server/auth/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/und/server/auth/filter/JwtAuthenticationFilterTest.java
@@ -22,9 +22,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.jwt.JwtProvider;
 import com.und.server.common.dto.ErrorResponse;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
 import jakarta.servlet.FilterChain;
@@ -65,7 +65,7 @@ class JwtAuthenticationFilterTest {
 		request.setServletPath(protectedPath);
 		request.addHeader("Authorization", "Bearer " + token);
 
-		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
+		final AuthErrorResult expectedError = AuthErrorResult.EXPIRED_TOKEN;
 		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
@@ -95,7 +95,7 @@ class JwtAuthenticationFilterTest {
 		request.setServletPath(path);
 		request.addHeader("Authorization", "Bearer " + token);
 
-		final ServerErrorResult expectedError = ServerErrorResult.INVALID_TOKEN_SIGNATURE;
+		final AuthErrorResult expectedError = AuthErrorResult.INVALID_TOKEN_SIGNATURE;
 		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
@@ -125,7 +125,7 @@ class JwtAuthenticationFilterTest {
 		request.setServletPath(loginPath);
 		request.addHeader("Authorization", "Bearer " + token);
 
-		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
+		final AuthErrorResult expectedError = AuthErrorResult.EXPIRED_TOKEN;
 		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when
@@ -150,7 +150,7 @@ class JwtAuthenticationFilterTest {
 		request.setServletPath(permissivePath);
 		request.addHeader("Authorization", "Bearer " + token);
 
-		final ServerErrorResult expectedError = ServerErrorResult.EXPIRED_TOKEN;
+		final AuthErrorResult expectedError = AuthErrorResult.EXPIRED_TOKEN;
 		doThrow(new ServerException(expectedError)).when(jwtProvider).getAuthentication(token);
 
 		// when

--- a/src/test/java/com/und/server/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/com/und/server/auth/jwt/JwtProviderTest.java
@@ -23,8 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.IdTokenPayload;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.common.util.ProfileManager;
 
@@ -66,7 +66,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getDecodedHeader(invalidToken))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getDecodedHeader(token))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -91,7 +91,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.extractNonce(invalidToken))
 				.isInstanceOf(ServerException.class)
-				.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN);
+				.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -133,7 +133,7 @@ class JwtProviderTest {
 		assertThatThrownBy(() -> {
 			jwtProvider.parseOidcIdToken(token, issuer, wrongAudience, publicKey);
 		}).isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -286,7 +286,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(token))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.EXPIRED_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.EXPIRED_TOKEN);
 	}
 
 	@Test
@@ -300,7 +300,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(malformedToken))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.MALFORMED_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.MALFORMED_TOKEN);
 	}
 
 	@Test
@@ -315,7 +315,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(token))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN_SIGNATURE);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN_SIGNATURE);
 	}
 
 	@Test
@@ -335,7 +335,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(tokenWithStrongAlg))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.WEAK_TOKEN_KEY)
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.WEAK_TOKEN_KEY)
 			.cause().isInstanceOf(WeakKeyException.class);
 	}
 
@@ -356,7 +356,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(unsupportedToken))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.UNSUPPORTED_TOKEN)
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.UNSUPPORTED_TOKEN)
 			.cause().isInstanceOf(UnsupportedJwtException.class);
 	}
 
@@ -371,7 +371,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(malformedToken))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.UNAUTHORIZED_ACCESS)
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.UNAUTHORIZED_ACCESS)
 			// Verify that the cause is the original exception
 			.cause().isInstanceOf(MalformedJwtException.class);
 	}
@@ -389,7 +389,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(token))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN)
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN)
 			.cause().isInstanceOf(NumberFormatException.class);
 	}
 
@@ -406,7 +406,7 @@ class JwtProviderTest {
 		// when & then
 		assertThatThrownBy(() -> jwtProvider.getMemberIdFromToken(token))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_TOKEN);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/oauth/OidcClientFactoryTest.java
+++ b/src/test/java/com/und/server/auth/oauth/OidcClientFactoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,7 +32,7 @@ class OidcClientFactoryTest {
 		// when & then
 		assertThatThrownBy(() -> oidcClientFactory.getOidcClient(null))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_PROVIDER);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/oauth/OidcProviderFactoryTest.java
+++ b/src/test/java/com/und/server/auth/oauth/OidcProviderFactoryTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.und.server.auth.dto.OidcPublicKeys;
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,7 +41,7 @@ class OidcProviderFactoryTest {
 		// when & then
 		assertThatThrownBy(() -> factory.getIdTokenPayload(null, token, oidcPublicKeys))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_PROVIDER);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/oauth/PublicKeyProviderTest.java
+++ b/src/test/java/com/und/server/auth/oauth/PublicKeyProviderTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.und.server.auth.dto.OidcPublicKey;
 import com.und.server.auth.dto.OidcPublicKeys;
-import com.und.server.common.exception.ServerErrorResult;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +42,7 @@ class PublicKeyProviderTest {
 		// then
 		assertThatThrownBy(() -> publicKeyProvider.generatePublicKey(header, oidcPublicKeys))
 			.isInstanceOf(ServerException.class)
-			.hasFieldOrPropertyWithValue("errorResult", ServerErrorResult.INVALID_PUBLIC_KEY);
+			.hasFieldOrPropertyWithValue("errorResult", AuthErrorResult.INVALID_PUBLIC_KEY);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/auth/service/NonceServiceTest.java
+++ b/src/test/java/com/und/server/auth/service/NonceServiceTest.java
@@ -19,9 +19,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.und.server.auth.entity.Nonce;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.Provider;
 import com.und.server.auth.repository.NonceRepository;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,7 +53,7 @@ class NonceServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.validateNonce(null, provider));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_NONCE);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_NONCE);
 	}
 
 	@Test
@@ -62,7 +62,7 @@ class NonceServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.validateNonce(nonceValue, null));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_PROVIDER);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class NonceServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.saveNonce(null, provider));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_NONCE);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_NONCE);
 	}
 
 	@Test
@@ -80,7 +80,7 @@ class NonceServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.saveNonce(nonceValue, null));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_PROVIDER);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test
@@ -104,7 +104,7 @@ class NonceServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.validateNonce(nonceValue, provider));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_NONCE);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_NONCE);
 	}
 
 	@Test
@@ -122,7 +122,7 @@ class NonceServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> nonceService.validateNonce(nonceValue, differentProvider));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_NONCE);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_NONCE);
 		// The nonce should not be deleted if the provider does not match
 		verify(nonceRepository, never()).deleteById(nonceValue);
 	}

--- a/src/test/java/com/und/server/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/und/server/auth/service/RefreshTokenServiceTest.java
@@ -18,9 +18,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.und.server.auth.entity.RefreshToken;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.repository.RefreshTokenRepository;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
+import com.und.server.member.exception.MemberErrorResult;
 
 @ExtendWith(MockitoExtension.class)
 class RefreshTokenServiceTest {
@@ -70,7 +71,7 @@ class RefreshTokenServiceTest {
 			() -> refreshTokenService.saveRefreshToken(memberId, null));
 
 		// then
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -81,7 +82,7 @@ class RefreshTokenServiceTest {
 			() -> refreshTokenService.validateRefreshToken(memberId, null));
 
 		// then
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_TOKEN);
 	}
 
 	@Test
@@ -91,7 +92,7 @@ class RefreshTokenServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> refreshTokenService.saveRefreshToken(null, refreshTokenValue));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.INVALID_MEMBER_ID);
 	}
 
 	@Test
@@ -101,7 +102,7 @@ class RefreshTokenServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> refreshTokenService.validateRefreshToken(null, refreshTokenValue));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.INVALID_MEMBER_ID);
 	}
 
 	@Test
@@ -111,7 +112,7 @@ class RefreshTokenServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> refreshTokenService.deleteRefreshToken(null));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.INVALID_MEMBER_ID);
 	}
 
 	@Test
@@ -143,7 +144,7 @@ class RefreshTokenServiceTest {
 			() -> refreshTokenService.validateRefreshToken(memberId, "wrong-token"));
 
 		// then
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_TOKEN);
 		verify(refreshTokenRepository).deleteById(memberId);
 	}
 
@@ -162,7 +163,7 @@ class RefreshTokenServiceTest {
 			() -> refreshTokenService.validateRefreshToken(memberId, refreshTokenValue));
 
 		// then
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_TOKEN);
 		verify(refreshTokenRepository).deleteById(memberId);
 	}
 
@@ -177,7 +178,7 @@ class RefreshTokenServiceTest {
 			() -> refreshTokenService.validateRefreshToken(memberId, refreshTokenValue));
 
 		// then
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_TOKEN);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_TOKEN);
 		verify(refreshTokenRepository).deleteById(memberId);
 	}
 

--- a/src/test/java/com/und/server/common/controller/TestControllerTest.java
+++ b/src/test/java/com/und/server/common/controller/TestControllerTest.java
@@ -25,14 +25,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.und.server.auth.dto.AuthResponse;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.filter.AuthMemberArgumentResolver;
 import com.und.server.auth.service.AuthService;
 import com.und.server.common.dto.TestAuthRequest;
 import com.und.server.common.exception.GlobalExceptionHandler;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.MemberResponse;
 import com.und.server.member.entity.Member;
+import com.und.server.member.exception.MemberErrorResult;
 import com.und.server.member.service.MemberService;
 
 @ExtendWith(MockitoExtension.class)
@@ -137,7 +138,7 @@ class TestControllerTest {
 		final String url = "/v1/test/hello";
 		final Long memberId = 3L;
 
-		doThrow(new ServerException(ServerErrorResult.MEMBER_NOT_FOUND)).when(memberService).findMemberById(memberId);
+		doThrow(new ServerException(MemberErrorResult.MEMBER_NOT_FOUND)).when(memberService).findMemberById(memberId);
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
 
@@ -148,8 +149,8 @@ class TestControllerTest {
 
 		// then
 		result.andExpect(status().isNotFound())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.MEMBER_NOT_FOUND.name()))
-			.andExpect(jsonPath("$.message").value(ServerErrorResult.MEMBER_NOT_FOUND.getMessage()));
+			.andExpect(jsonPath("$.code").value(MemberErrorResult.MEMBER_NOT_FOUND.name()))
+			.andExpect(jsonPath("$.message").value(MemberErrorResult.MEMBER_NOT_FOUND.getMessage()));
 	}
 
 	@Test
@@ -157,7 +158,7 @@ class TestControllerTest {
 	void Given_UnauthenticatedUser_When_Greet_Then_ReturnsUnauthorized() throws Exception {
 		// given
 		final String url = "/v1/test/hello";
-		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doThrow(new ServerException(errorResult))

--- a/src/test/java/com/und/server/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/und/server/member/controller/MemberControllerTest.java
@@ -21,9 +21,10 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.filter.AuthMemberArgumentResolver;
+import com.und.server.common.exception.CommonErrorResult;
 import com.und.server.common.exception.GlobalExceptionHandler;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.MemberResponse;
 import com.und.server.member.dto.NicknameRequest;
@@ -73,7 +74,7 @@ class MemberControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(ServerErrorResult.INVALID_PARAMETER.name()))
+			.andExpect(jsonPath("$.code").value(CommonErrorResult.INVALID_PARAMETER.name()))
 			.andExpect(jsonPath("$.message[0]").value("Nickname must not be blank"));
 	}
 
@@ -84,7 +85,7 @@ class MemberControllerTest {
 		final String url = "/v1/member/nickname";
 		final NicknameRequest request = new NicknameRequest("new-nickname");
 		final String requestBody = objectMapper.writeValueAsString(request);
-		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doThrow(new ServerException(errorResult))
@@ -135,7 +136,7 @@ class MemberControllerTest {
 	void Given_UnauthenticatedUser_When_DeleteMember_Then_ReturnsUnauthorized() throws Exception {
 		// given
 		final String url = "/v1/member";
-		final ServerErrorResult errorResult = ServerErrorResult.UNAUTHORIZED_ACCESS;
+		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
 		doThrow(new ServerException(errorResult))

--- a/src/test/java/com/und/server/member/service/MemberServiceTest.java
+++ b/src/test/java/com/und/server/member/service/MemberServiceTest.java
@@ -18,14 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.und.server.auth.exception.AuthErrorResult;
 import com.und.server.auth.oauth.IdTokenPayload;
 import com.und.server.auth.oauth.Provider;
 import com.und.server.auth.service.RefreshTokenService;
-import com.und.server.common.exception.ServerErrorResult;
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.MemberResponse;
 import com.und.server.member.dto.NicknameRequest;
 import com.und.server.member.entity.Member;
+import com.und.server.member.exception.MemberErrorResult;
 import com.und.server.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -101,7 +102,7 @@ class MemberServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.findOrCreateMember(unsupportedProvider, payload));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_PROVIDER);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test
@@ -114,7 +115,7 @@ class MemberServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.findOrCreateMember(null, payload));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_PROVIDER);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_PROVIDER);
 	}
 
 	@Test
@@ -127,7 +128,7 @@ class MemberServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.findOrCreateMember(provider, payloadWithNullId));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_PROVIDER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(AuthErrorResult.INVALID_PROVIDER_ID);
 	}
 
 	@Test
@@ -140,7 +141,7 @@ class MemberServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.findMemberById(memberId));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.MEMBER_NOT_FOUND);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.MEMBER_NOT_FOUND);
 	}
 
 	@Test
@@ -150,7 +151,7 @@ class MemberServiceTest {
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.findMemberById(null));
 
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.INVALID_MEMBER_ID);
 	}
 
 	@Test
@@ -159,7 +160,7 @@ class MemberServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.validateMemberExists(null));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.INVALID_MEMBER_ID);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.INVALID_MEMBER_ID);
 	}
 
 	@Test
@@ -171,7 +172,7 @@ class MemberServiceTest {
 		// when & then
 		final ServerException exception = assertThrows(ServerException.class,
 			() -> memberService.validateMemberExists(memberId));
-		assertThat(exception.getErrorResult()).isEqualTo(ServerErrorResult.MEMBER_NOT_FOUND);
+		assertThat(exception.getErrorResult()).isEqualTo(MemberErrorResult.MEMBER_NOT_FOUND);
 	}
 
 	@Test


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] refactor: 코드 리팩토링

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
refactor/#84-error -> dev

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
ErrorResult 인터페이스를 도입함에 따라 ServerErrorResult를 AuthErrorResult, MemberErrorResult, CommonErrorResult로 분리했습니다.
AuthErrorResult를 생성하고 인증 관련 예외를 포함했습니다.
MemberErrorResult를 생성하고 회원 관련 예외를 포함했습니다.
CommonErrorResult를 생성하고 공통 예외를 포함했습니다.

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="1452" height="293" alt="Screenshot 2025-08-03 at 1 34 26 PM" src="https://github.com/user-attachments/assets/48d0240a-d73d-4f8c-9aba-34804c714b63" />

### 📂 관련 이슈
<!-- 예) #5 -->
#84 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
소스 코드에서 도메인별로 예외를 분리만 했으며 비즈니스 로직은 변경 사항 없습니다~!
그리고 `validate-pr.yml`과 `build.gradle`에서 자잘한 오타를 수정한 것과 Controller에서 Delete Method에만 ApiResponse를 추가해서 Swagger에서 204 응답을 반환다고 표시되도록 한 것이 있습니당.