### PR TITLE
Feat/#73 scenario backup

### DIFF
--- a/src/main/java/com/und/server/ServerApplication.java
+++ b/src/main/java/com/und/server/ServerApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 @ConfigurationPropertiesScan
 public class ServerApplication {
 

--- a/src/main/java/com/und/server/common/config/TimeConfig.java
+++ b/src/main/java/com/und/server/common/config/TimeConfig.java
@@ -1,0 +1,17 @@
+package com.und.server.common.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+	@Bean
+	public Clock clock() {
+		return Clock.system(ZoneId.of("Asia/Seoul"));
+	}
+
+}

--- a/src/main/java/com/und/server/common/config/TimeConfig.java
+++ b/src/main/java/com/und/server/common/config/TimeConfig.java
@@ -1,7 +1,6 @@
 package com.und.server.common.config;
 
 import java.time.Clock;
-import java.time.ZoneId;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +10,7 @@ public class TimeConfig {
 
 	@Bean
 	public Clock clock() {
-		return Clock.system(ZoneId.of("Asia/Seoul"));
+		return Clock.systemUTC();
 	}
 
 }

--- a/src/main/java/com/und/server/scenario/repository/MissionRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/MissionRepository.java
@@ -26,7 +26,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 			AND (m.useDate IS NULL OR m.useDate = :date)
 		""")
 	@NotNull
-	List<Mission> findDefaultMissions(@NotNull Long memberId, @NotNull Long scenarioId, @NotNull LocalDate date);
+	List<Mission> findTodayAndFutureMissions(
+		@NotNull Long memberId, @NotNull Long scenarioId, @NotNull LocalDate date);
 
 	@Query("""
 		SELECT m FROM Mission m
@@ -36,7 +37,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 			AND m.useDate = :date
 		""")
 	@NotNull
-	List<Mission> findMissionsByDate(@NotNull Long memberId, @NotNull Long scenarioId, @NotNull LocalDate date);
+	List<Mission> findPastMissionsByDate(
+		@NotNull Long memberId, @NotNull Long scenarioId, @NotNull LocalDate date);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("DELETE FROM Mission m WHERE m.scenario.id = :scenarioId")

--- a/src/main/java/com/und/server/scenario/repository/MissionRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/MissionRepository.java
@@ -65,11 +65,20 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 	int bulkCloneBasicToYesterday(LocalDate yesterday);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
-	@Query("""
-		DELETE FROM Mission m
-		WHERE m.useDate IS NOT NULL
-		  AND m.useDate < :expireBefore
-		""")
-	int bulkDeleteExpired(LocalDate expireBefore);
+	@Query(value = """
+		DELETE FROM mission
+		WHERE use_date IS NOT NULL
+		  AND use_date < :expireBefore
+		LIMIT :limit
+		""", nativeQuery = true)
+	int bulkDeleteExpired(LocalDate expireBefore, int limit);
+
+//	@Modifying(clearAutomatically = true, flushAutomatically = true)
+//	@Query("""
+//		DELETE FROM Mission m
+//		WHERE m.useDate IS NOT NULL
+//		  AND m.useDate < :expireBefore
+//		""")
+//	int bulkDeleteExpired(LocalDate expireBefore);
 
 }

--- a/src/main/java/com/und/server/scenario/repository/MissionRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/MissionRepository.java
@@ -38,6 +38,9 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 	@NotNull
 	List<Mission> findMissionsByDate(@NotNull Long memberId, @NotNull Long scenarioId, @NotNull LocalDate date);
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("DELETE FROM Mission m WHERE m.scenario.id = :scenarioId")
+	int deleteByScenarioId(Long scenarioId);
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("""

--- a/src/main/java/com/und/server/scenario/repository/MissionRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/MissionRepository.java
@@ -47,20 +47,20 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 		UPDATE Mission m
 		SET m.isChecked = false
 		WHERE m.useDate IS NULL
-		  AND m.missionType = 'BASIC'
+			AND m.missionType = 'BASIC'
 		""")
-	int resetBasicIsChecked();
+	int bulkResetBasicIsChecked();
 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query(value = """
 		INSERT INTO mission (
-		  scenario_id, content, is_checked, mission_order, use_date, mission_type, created_at, updated_at
+			scenario_id, content, is_checked, mission_order, use_date, mission_type, created_at, updated_at
 		)
 		SELECT m.scenario_id, m.content, m.is_checked, m.mission_order, :yesterday, m.mission_type,
-		       CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+			CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 		FROM mission m
 		WHERE m.use_date IS NULL
-		  AND m.mission_type = 'BASIC'
+			AND m.mission_type = 'BASIC'
 		""", nativeQuery = true)
 	int bulkCloneBasicToYesterday(LocalDate yesterday);
 
@@ -68,17 +68,9 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 	@Query(value = """
 		DELETE FROM mission
 		WHERE use_date IS NOT NULL
-		  AND use_date < :expireBefore
+			AND use_date < :expireBefore
 		LIMIT :limit
 		""", nativeQuery = true)
 	int bulkDeleteExpired(LocalDate expireBefore, int limit);
-
-//	@Modifying(clearAutomatically = true, flushAutomatically = true)
-//	@Query("""
-//		DELETE FROM Mission m
-//		WHERE m.useDate IS NOT NULL
-//		  AND m.useDate < :expireBefore
-//		""")
-//	int bulkDeleteExpired(LocalDate expireBefore);
 
 }

--- a/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
@@ -1,9 +1,9 @@
 package com.und.server.scenario.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -26,7 +26,18 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 			AND m.missionType = 'BASIC'
 			AND m.useDate IS NULL
 		""")
-	Optional<Scenario> findTodayScenarioFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
+	Optional<Scenario> findScenarioDetailFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
+
+	@Query("""
+		SELECT s FROM Scenario s
+		LEFT JOIN FETCH s.notification
+		LEFT JOIN FETCH s.missions m
+		WHERE s.id = :id
+			AND s.member.id = :memberId
+			AND (m.useDate IS NULL OR m.useDate = :date)
+		""")
+	Optional<Scenario> findTodayScenarioFetchByIdAndMemberId(
+		@NotNull Long memberId, @NotNull Long id, @NotNull LocalDate date);
 
 
 

--- a/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
@@ -48,16 +48,6 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 
 	@Query("""
 		SELECT s FROM Scenario s
-		LEFT JOIN FETCH s.notification
-		LEFT JOIN FETCH s.missions
-		WHERE s.id = :id
-			AND s.member.id = :memberId
-		""")
-		//fixme 안씀
-	Optional<Scenario> findFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
-
-	@Query("""
-		SELECT s FROM Scenario s
 		WHERE s.member.id = :memberId
 			AND s.notification.notificationType = :notificationType
 		ORDER BY s.scenarioOrder

--- a/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
@@ -16,7 +16,6 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 
 	Optional<Scenario> findByIdAndMemberId(@NotNull Long id, @NotNull Long memberId);
 
-
 	@Query("""
 		SELECT s FROM Scenario s
 		LEFT JOIN FETCH s.notification
@@ -39,8 +38,13 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 	Optional<Scenario> findTodayScenarioFetchByIdAndMemberId(
 		@NotNull Long memberId, @NotNull Long id, @NotNull LocalDate date);
 
-
-
+	@Query("""
+		SELECT s FROM Scenario s
+		LEFT JOIN FETCH s.notification
+		WHERE s.id = :id
+			AND s.member.id = :memberId
+		""")
+	Optional<Scenario> findNotificationFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
 
 	@Query("""
 		SELECT s FROM Scenario s
@@ -49,6 +53,7 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 		WHERE s.id = :id
 			AND s.member.id = :memberId
 		""")
+		//fixme 안씀
 	Optional<Scenario> findFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
 
 	@Query("""

--- a/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
@@ -16,6 +16,21 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long>, Scena
 
 	Optional<Scenario> findByIdAndMemberId(@NotNull Long id, @NotNull Long memberId);
 
+
+	@Query("""
+		SELECT s FROM Scenario s
+		LEFT JOIN FETCH s.notification
+		LEFT JOIN FETCH s.missions m
+		WHERE s.id = :id
+			AND s.member.id = :memberId
+			AND m.missionType = 'BASIC'
+			AND m.useDate IS NULL
+		""")
+	Optional<Scenario> findTodayScenarioFetchByIdAndMemberId(@NotNull Long memberId, @NotNull Long id);
+
+
+
+
 	@Query("""
 		SELECT s FROM Scenario s
 		LEFT JOIN FETCH s.notification

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -17,15 +17,18 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ScenarioMissionDailyJob {
 
+	private static final int DEFAULT_DELETE_LIMIT = 10_000;
+	private static final int DAYS_TO_SUBTRACT = 1;
+	private static final int MONTHS_TO_SUBTRACT = 1;
 	private final MissionRepository missionRepository;
 
 	//테스트를 위해ㅏ며 3분마다
-	@Scheduled(cron = "0 */3 * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 */2 * * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runDailyJob() {
 		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-		LocalDate yesterday = today.minusDays(1);
-		LocalDate expireBefore = today.minusMonths(1);
+		LocalDate yesterday = today.minusDays(DAYS_TO_SUBTRACT);
+		LocalDate expireBefore = today.minusMonths(MONTHS_TO_SUBTRACT);
 
 		// 1. BASIC 백업
 		int cloned = missionRepository.bulkCloneBasicToYesterday(yesterday);
@@ -34,9 +37,17 @@ public class ScenarioMissionDailyJob {
 		int reset = missionRepository.resetBasicIsChecked();
 
 		// 3. 만료 미션 삭제
-		int deleted = missionRepository.bulkDeleteExpired(expireBefore);
+		int deleted = missionRepository.bulkDeleteExpired(expireBefore, DEFAULT_DELETE_LIMIT);
 
 		log.info("[BACK UP] Daily Mission Job: cloned={}, reset={}, deleted={}", cloned, reset, deleted);
 	}
+	/**
+	 * 확인해야할 사항
+	 * 1. 미션 백업 - 체크상태는 그대로
+	 * 2. 미션 체크리스트 초기화 - useDate가 null인 경우만
+	 * 3. Today는 그대로인지
+	 *
+	 * 1. 미션 생성
+	 */
 
 }

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -1,0 +1,42 @@
+package com.und.server.scenario.scheduler;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.und.server.scenario.repository.MissionRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ScenarioMissionDailyJob {
+
+	private final MissionRepository missionRepository;
+
+	//테스트를 위해ㅏ며 3분마다
+	@Scheduled(cron = "0 */3 * * * *", zone = "Asia/Seoul")
+	@Transactional
+	public void runDailyJob() {
+		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		LocalDate yesterday = today.minusDays(1);
+		LocalDate expireBefore = today.minusMonths(1);
+
+		// 1. BASIC 백업
+		int cloned = missionRepository.bulkCloneBasicToYesterday(yesterday);
+
+		// 2. BASIC 원본 초기화
+		int reset = missionRepository.resetBasicIsChecked();
+
+		// 3. 만료 미션 삭제
+		int deleted = missionRepository.bulkDeleteExpired(expireBefore);
+
+		log.info("[BACK UP] Daily Mission Job: cloned={}, reset={}, deleted={}", cloned, reset, deleted);
+	}
+
+}

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -51,8 +51,9 @@ public class ScenarioMissionDailyJob {
 		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 		LocalDate expireBefore = today.minusMonths(MONTHS_TO_SUBTRACT);
 
+		int totalDeleted = 0;
+
 		try {
-			int totalDeleted = 0;
 			int batchDeleted;
 
 			do {
@@ -62,7 +63,8 @@ public class ScenarioMissionDailyJob {
 
 			log.info("[MISSION DAILY] Expired mission cleanup completed: deleted={}", totalDeleted);
 		} catch (Exception e) {
-			log.error("[MISSION DAILY] Expired mission cleanup failed. expireBefore={}", expireBefore, e);
+			log.error("[MISSION DAILY] Expired mission cleanup failed. expireBefore={}, deletedUntilError={}",
+				expireBefore, totalDeleted, e);
 		}
 	}
 

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -2,6 +2,7 @@ package com.und.server.scenario.scheduler;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -29,7 +30,7 @@ public class ScenarioMissionDailyJob {
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runDailyBackupJob() {
-		LocalDate today = LocalDate.now(clock);
+		LocalDate today = LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul")));
 		LocalDate yesterday = today.minusDays(DAYS_TO_SUBTRACT);
 
 		try {
@@ -49,7 +50,7 @@ public class ScenarioMissionDailyJob {
 	@Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runExpiredMissionCleanupJob() {
-		LocalDate today = LocalDate.now(clock);
+		LocalDate today = LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul")));
 		LocalDate expireBefore = today.minusMonths(MONTHS_TO_SUBTRACT);
 
 		int totalDeleted = 0;

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -22,6 +22,9 @@ public class ScenarioMissionDailyJob {
 	private static final int MONTHS_TO_SUBTRACT = 1;
 	private final MissionRepository missionRepository;
 
+	/**
+	 * Daily job at midnight (00:00) - BASIC 미션 백업, DEFAULT BASIC 미션 체크상태 리셋
+	 */
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runDailyBackupJob() {
@@ -39,6 +42,9 @@ public class ScenarioMissionDailyJob {
 		}
 	}
 
+	/**
+	 * Daily cleanup job at 1 AM (01:00) - 기간 만료 미션 삭제
+	 */
 	@Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runExpiredMissionCleanupJob() {

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -1,7 +1,7 @@
 package com.und.server.scenario.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDate;
-import java.time.ZoneId;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,6 +21,7 @@ public class ScenarioMissionDailyJob {
 	private static final int DAYS_TO_SUBTRACT = 1;
 	private static final int MONTHS_TO_SUBTRACT = 1;
 	private final MissionRepository missionRepository;
+	private final Clock clock;
 
 	/**
 	 * Daily job at midnight (00:00) - BASIC 미션 백업, DEFAULT BASIC 미션 체크상태 리셋
@@ -28,7 +29,7 @@ public class ScenarioMissionDailyJob {
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runDailyBackupJob() {
-		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		LocalDate today = LocalDate.now(clock);
 		LocalDate yesterday = today.minusDays(DAYS_TO_SUBTRACT);
 
 		try {
@@ -48,7 +49,7 @@ public class ScenarioMissionDailyJob {
 	@Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void runExpiredMissionCleanupJob() {
-		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		LocalDate today = LocalDate.now(clock);
 		LocalDate expireBefore = today.minusMonths(MONTHS_TO_SUBTRACT);
 
 		int totalDeleted = 0;

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -182,11 +182,11 @@ public class MissionService {
 		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(today, date);
 
 		switch (missionSearchType) {
-			case TODAY -> {
-				return missionRepository.findDefaultMissions(memberId, scenarioId, date);
+			case TODAY, FUTURE -> {
+				return missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date);
 			}
-			case PAST, FUTURE -> {
-				return missionRepository.findMissionsByDate(memberId, scenarioId, date);
+			case PAST -> {
+				return missionRepository.findPastMissionsByDate(memberId, scenarioId, date);
 			}
 		}
 		throw new ServerException(ScenarioErrorResult.INVALID_MISSION_FOUND_DATE);

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -1,6 +1,8 @@
 package com.und.server.scenario.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,7 @@ public class MissionService {
 	private final MissionTypeGroupSorter missionTypeGroupSorter;
 	private final ScenarioValidator scenarioValidator;
 	private final MissionValidator missionValidator;
+	private final Clock clock;
 
 
 	@Transactional(readOnly = true)
@@ -84,7 +87,7 @@ public class MissionService {
 		final TodayMissionRequest todayMissionRequest,
 		final LocalDate date
 	) {
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul")));
 		missionValidator.validateTodayMissionDateRange(today, date);
 
 		List<Mission> todayMissions = missionTypeGroupSorter.groupAndSortByType(
@@ -178,7 +181,7 @@ public class MissionService {
 	private List<Mission> getMissionsByDate(
 		final Long memberId, final Long scenarioId, final LocalDate date
 	) {
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul")));
 		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(today, date);
 
 		switch (missionSearchType) {

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -160,6 +160,12 @@ public class MissionService {
 
 
 	@Transactional
+	public void deleteMissions(final Long scenarioId) {
+		missionRepository.deleteByScenarioId(scenarioId);
+	}
+
+
+	@Transactional
 	public void deleteTodayMission(final Long memberId, final Long missionId) {
 		Mission mission = missionRepository.findById(missionId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_MISSION));

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -1,6 +1,8 @@
 package com.und.server.scenario.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,6 +51,7 @@ public class ScenarioService {
 	private final ScenarioValidator scenarioValidator;
 	private final EntityManager em;
 	private final NotificationEventPublisher notificationEventPublisher;
+	private final Clock clock;
 
 
 	@Transactional(readOnly = true)
@@ -157,7 +160,8 @@ public class ScenarioService {
 
 		notificationEventPublisher.publishUpdateEvent(memberId, oldScenario, isOldScenarioNotificationActive);
 
-		return missionService.findMissionsByScenarioId(memberId, scenarioId, LocalDate.now());
+		return missionService.findMissionsByScenarioId(
+			memberId, scenarioId, LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul"))));
 	}
 
 

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -61,10 +61,10 @@ public class ScenarioService {
 		return ScenarioResponse.listFrom(scenarios);
 	}
 
-
+	//BASIC은 useDate가 Null인것, TODAY는 그냥 요청 날짜
 	@Transactional(readOnly = true)
 	public ScenarioDetailResponse findScenarioDetailByScenarioId(final Long memberId, final Long scenarioId) {
-		Scenario scenario = scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario scenario = scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 
 		List<Mission> basicMissions =
@@ -138,7 +138,7 @@ public class ScenarioService {
 		final Long scenarioId,
 		final ScenarioDetailRequest scenarioDetailRequest
 	) {
-		Scenario oldScenario = scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario oldScenario = scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 		Notification oldNotification = oldScenario.getNotification();
 

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -61,6 +61,7 @@ public class ScenarioService {
 		return ScenarioResponse.listFrom(scenarios);
 	}
 
+
 	@Transactional(readOnly = true)
 	public ScenarioDetailResponse findScenarioDetailByScenarioId(final Long memberId, final Long scenarioId) {
 		Scenario scenario = scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId)

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -61,10 +61,9 @@ public class ScenarioService {
 		return ScenarioResponse.listFrom(scenarios);
 	}
 
-	//BASIC은 useDate가 Null인것, TODAY는 그냥 요청 날짜
 	@Transactional(readOnly = true)
 	public ScenarioDetailResponse findScenarioDetailByScenarioId(final Long memberId, final Long scenarioId) {
-		Scenario scenario = scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario scenario = scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 
 		List<Mission> basicMissions =
@@ -88,7 +87,7 @@ public class ScenarioService {
 		final TodayMissionRequest todayMissionRequest,
 		final LocalDate date
 	) {
-		Scenario scenario = scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario scenario = scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId, date)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 
 		return missionService.addTodayMission(scenario, todayMissionRequest, date);
@@ -138,7 +137,7 @@ public class ScenarioService {
 		final Long scenarioId,
 		final ScenarioDetailRequest scenarioDetailRequest
 	) {
-		Scenario oldScenario = scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario oldScenario = scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 		Notification oldNotification = oldScenario.getNotification();
 

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -191,11 +191,13 @@ public class ScenarioService {
 
 	@Transactional
 	public void deleteScenarioWithAllMissions(final Long memberId, final Long scenarioId) {
-		Scenario scenario = scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId)
+		Scenario scenario = scenarioRepository.findNotificationFetchByIdAndMemberId(memberId, scenarioId)
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_SCENARIO));
 
 		Notification notification = scenario.getNotification();
 		boolean isNotificationActive = notification.isActive();
+
+		missionService.deleteMissions(scenarioId);
 
 		notificationService.deleteNotification(notification);
 		scenarioRepository.delete(scenario);

--- a/src/main/java/com/und/server/weather/controller/WeatherController.java
+++ b/src/main/java/com/und/server/weather/controller/WeatherController.java
@@ -29,9 +29,10 @@ public class WeatherController {
 	@PostMapping
 	public ResponseEntity<WeatherResponse> getWeather(
 		@RequestBody @Valid final WeatherRequest request,
-		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") final LocalDate date
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") final LocalDate date,
+		@RequestParam(defaultValue = "Asia/Seoul") final String timezone
 	) {
-		final WeatherResponse response = weatherService.getWeatherInfo(request, date);
+		final WeatherResponse response = weatherService.getWeatherInfo(request, date, timezone);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/und/server/weather/service/WeatherService.java
+++ b/src/main/java/com/und/server/weather/service/WeatherService.java
@@ -1,7 +1,9 @@
 package com.und.server.weather.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import org.springframework.stereotype.Service;
 
@@ -21,12 +23,13 @@ public class WeatherService {
 
 	private static final int MAX_FUTURE_DATE = 3;
 	private final WeatherCacheService weatherCacheService;
+	private final Clock clock;
 
 
 	public WeatherResponse getWeatherInfo(
-		final WeatherRequest weatherRequest, final LocalDate date
+		final WeatherRequest weatherRequest, final LocalDate date, final String timezone
 	) {
-		LocalDateTime nowDateTime = LocalDateTime.now();
+		LocalDateTime nowDateTime = LocalDateTime.now(clock.withZone(ZoneId.of(timezone)));
 		LocalDate today = nowDateTime.toLocalDate();
 
 		validateLocation(weatherRequest);

--- a/src/test/java/com/und/server/scenario/constants/MissionSearchTypeTest.java
+++ b/src/test/java/com/und/server/scenario/constants/MissionSearchTypeTest.java
@@ -48,7 +48,7 @@ class MissionSearchTypeTest {
 	@DisplayName("오늘 날짜로 요청하면 TODAY 타입을 반환")
 	void Given_TodayDate_When_GetMissionSearchType_Then_ReturnToday() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today;
 
 		// when
@@ -62,7 +62,7 @@ class MissionSearchTypeTest {
 	@DisplayName("null 날짜로 요청하면 TODAY 타입을 반환")
 	void Given_NullDate_When_GetMissionSearchType_Then_ReturnToday() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = null;
 
 		// when
@@ -76,7 +76,7 @@ class MissionSearchTypeTest {
 	@DisplayName("어제 날짜로 요청하면 PAST 타입을 반환")
 	void Given_YesterdayDate_When_GetMissionSearchType_Then_ReturnPast() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.minusDays(1);
 
 		// when
@@ -90,7 +90,7 @@ class MissionSearchTypeTest {
 	@DisplayName("7일 전 날짜로 요청하면 PAST 타입을 반환")
 	void Given_SevenDaysAgoDate_When_GetMissionSearchType_Then_ReturnPast() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.minusDays(7);
 
 		// when
@@ -104,7 +104,7 @@ class MissionSearchTypeTest {
 	@DisplayName("8일 전 날짜로 요청하면 예외 발생")
 	void Given_EightDaysAgoDate_When_GetMissionSearchType_Then_ThrowException() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.minusDays(40);
 
 		// when & then
@@ -117,7 +117,7 @@ class MissionSearchTypeTest {
 	@DisplayName("내일 날짜로 요청하면 FUTURE 타입을 반환")
 	void Given_TomorrowDate_When_GetMissionSearchType_Then_ReturnFuture() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.plusDays(1);
 
 		// when
@@ -131,7 +131,7 @@ class MissionSearchTypeTest {
 	@DisplayName("7일 후 날짜로 요청하면 FUTURE 타입을 반환")
 	void Given_SevenDaysLaterDate_When_GetMissionSearchType_Then_ReturnFuture() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.plusDays(7);
 
 		// when
@@ -145,7 +145,7 @@ class MissionSearchTypeTest {
 	@DisplayName("8일 후 날짜로 요청하면 예외 발생")
 	void Given_EightDaysLaterDate_When_GetMissionSearchType_Then_ThrowException() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 		LocalDate requestDate = today.plusDays(40);
 
 		// when & then
@@ -158,7 +158,7 @@ class MissionSearchTypeTest {
 	@DisplayName("범위 내 과거 날짜들로 요청하면 모두 PAST 타입을 반환")
 	void Given_PastDatesInRange_When_GetMissionSearchType_Then_ReturnPast() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 
 		// when & then
 		for (int i = 1; i <= 7; i++) {
@@ -172,7 +172,7 @@ class MissionSearchTypeTest {
 	@DisplayName("범위 내 미래 날짜들로 요청하면 모두 FUTURE 타입을 반환")
 	void Given_FutureDatesInRange_When_GetMissionSearchType_Then_ReturnFuture() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 
 		// when & then
 		for (int i = 1; i <= 7; i++) {
@@ -186,7 +186,7 @@ class MissionSearchTypeTest {
 	@DisplayName("범위를 벗어난 과거 날짜들로 요청하면 모두 예외 발생")
 	void Given_PastDatesOutOfRange_When_GetMissionSearchType_Then_ThrowException() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 
 		// when & then
 		for (int i = 15; i <= 17; i++) {
@@ -201,7 +201,7 @@ class MissionSearchTypeTest {
 	@DisplayName("범위를 벗어난 미래 날짜들로 요청하면 모두 예외 발생")
 	void Given_FutureDatesOutOfRange_When_GetMissionSearchType_Then_ThrowException() {
 		// given
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
 
 		// when & then
 		for (int i = 15; i <= 17; i++) {

--- a/src/test/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJobTest.java
+++ b/src/test/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJobTest.java
@@ -1,0 +1,100 @@
+package com.und.server.scenario.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.und.server.scenario.repository.MissionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ScenarioMissionDailyJobTest {
+
+	@Mock
+	private MissionRepository missionRepository;
+
+	@InjectMocks
+	private ScenarioMissionDailyJob job;
+
+
+	@Test
+	void Given_NormalCase_When_RunDailyBackupJob_Then_CloneAndResetCalled() {
+		// given
+		when(missionRepository.bulkCloneBasicToYesterday(any(LocalDate.class))).thenReturn(7);
+		when(missionRepository.bulkResetBasicIsChecked()).thenReturn(100);
+
+		// when
+		job.runDailyBackupJob();
+
+		// then
+		ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
+		verify(missionRepository, times(1)).bulkCloneBasicToYesterday(dateCaptor.capture());
+		verify(missionRepository, times(1)).bulkResetBasicIsChecked();
+
+		LocalDate captured = dateCaptor.getValue();
+		LocalDate expectedYesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+		org.assertj.core.api.Assertions.assertThat(captured).isEqualTo(expectedYesterday);
+	}
+
+
+	@Test
+	void Given_RepositoryThrows_When_RunDailyBackupJob_Then_Throws() {
+		// given
+		when(missionRepository.bulkCloneBasicToYesterday(any(LocalDate.class)))
+			.thenThrow(new RuntimeException("db error"));
+
+		// then
+		assertThatThrownBy(() -> job.runDailyBackupJob()).isInstanceOf(RuntimeException.class);
+	}
+
+
+	@Test
+	void Given_ZeroDeleted_When_RunExpiredCleanupJob_Then_CallOnceAndNoThrow() {
+		// given
+		when(missionRepository.bulkDeleteExpired(any(LocalDate.class), anyInt())).thenReturn(0);
+
+		// when & then
+		assertThatCode(() -> job.runExpiredMissionCleanupJob()).doesNotThrowAnyException();
+		verify(missionRepository, times(1)).bulkDeleteExpired(any(LocalDate.class), anyInt());
+	}
+
+
+	@Test
+	void Given_DefaultBatchThenSmaller_When_RunExpiredCleanupJob_Then_LoopsAndStops() {
+		// given
+		when(missionRepository.bulkDeleteExpired(any(LocalDate.class), anyInt()))
+			.thenReturn(10_000)
+			.thenReturn(5_000);
+
+		// when
+		assertThatCode(() -> job.runExpiredMissionCleanupJob()).doesNotThrowAnyException();
+
+		// then: 두 번 호출됨
+		verify(missionRepository, times(2)).bulkDeleteExpired(any(LocalDate.class), anyInt());
+	}
+
+
+	@Test
+	void Given_RepositoryThrows_When_RunExpiredCleanupJob_Then_NoThrow() {
+		// given
+		when(missionRepository.bulkDeleteExpired(any(LocalDate.class), anyInt()))
+			.thenThrow(new RuntimeException("db error"));
+
+		// when & then
+		assertThatCode(() -> job.runExpiredMissionCleanupJob()).doesNotThrowAnyException();
+	}
+
+}

--- a/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
@@ -8,16 +8,21 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.entity.Member;
@@ -32,6 +37,7 @@ import com.und.server.scenario.repository.MissionRepository;
 import com.und.server.scenario.util.MissionTypeGroupSorter;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MissionServiceTest {
 
 	@Mock
@@ -46,16 +52,27 @@ class MissionServiceTest {
 	@Mock
 	private com.und.server.scenario.util.MissionValidator missionValidator;
 
+	@Mock
+	private Clock clock;
+
 	@InjectMocks
 	private MissionService missionService;
 
+	@BeforeEach
+	void setUp() {
+		// Clock 설정
+		when(clock.withZone(ZoneId.of("Asia/Seoul"))).thenReturn(Clock.fixed(
+			LocalDate.of(2024, 1, 15).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant(),
+			ZoneId.of("Asia/Seoul")
+		));
+	}
 
 	@Test
 	void Given_ValidScenarioId_When_FindMissionsByScenarioId_Then_ReturnMissionGroupResponse() {
 		// given
 		Long memberId = 1L;
 		Long scenarioId = 1L;
-		LocalDate date = LocalDate.now();
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		Member member = Member.builder()
 			.id(memberId)
@@ -109,7 +126,7 @@ class MissionServiceTest {
 		// given
 		Long memberId = 1L;
 		Long scenarioId = 1L;
-		LocalDate date = LocalDate.now();
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date)).thenReturn(
 			List.of());
@@ -130,7 +147,7 @@ class MissionServiceTest {
 		// given
 		Long memberId = 1L;
 		Long scenarioId = 1L;
-		LocalDate date = LocalDate.now();
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date)).thenReturn(
 			List.of());
@@ -152,7 +169,7 @@ class MissionServiceTest {
 			.build();
 
 		TodayMissionRequest missionAddInfo = new TodayMissionRequest("오늘 미션");
-		LocalDate date = LocalDate.now();
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		// when
 		missionService.addTodayMission(scenario, missionAddInfo, date);
@@ -557,7 +574,7 @@ class MissionServiceTest {
 		// given
 		Long memberId = 1L;
 		Long scenarioId = 1L;
-		LocalDate pastDate = LocalDate.now().minusDays(1);
+		LocalDate pastDate = LocalDate.of(2024, 1, 14);
 
 		Mission mission = Mission.builder()
 			.id(1L)
@@ -592,7 +609,7 @@ class MissionServiceTest {
 		// given
 		Long memberId = 1L;
 		Long scenarioId = 1L;
-		LocalDate futureDate = LocalDate.now().plusDays(1);
+		LocalDate futureDate = LocalDate.of(2024, 1, 16);
 
 		Mission mission = Mission.builder()
 			.id(1L)

--- a/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
@@ -84,7 +84,7 @@ class MissionServiceTest {
 		List<Mission> groupedBasicMissions = Arrays.asList(basicMission);
 		List<Mission> groupedTodayMissions = Arrays.asList(todayMission);
 
-		when(missionRepository.findDefaultMissions(memberId, scenarioId, date)).thenReturn(
+		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date)).thenReturn(
 			missionList);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.BASIC))
 			.thenReturn(groupedBasicMissions);
@@ -98,7 +98,7 @@ class MissionServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.basicMissions()).isNotEmpty();
 		assertThat(result.todayMissions()).isNotEmpty();
-		verify(missionRepository).findDefaultMissions(memberId, scenarioId, date);
+		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 		verify(missionTypeGrouper).groupAndSortByType(missionList, MissionType.BASIC);
 		verify(missionTypeGrouper).groupAndSortByType(missionList, MissionType.TODAY);
 	}
@@ -111,7 +111,7 @@ class MissionServiceTest {
 		Long scenarioId = 1L;
 		LocalDate date = LocalDate.now();
 
-		when(missionRepository.findDefaultMissions(memberId, scenarioId, date)).thenReturn(
+		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date)).thenReturn(
 			List.of());
 
 		// when
@@ -121,7 +121,7 @@ class MissionServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.basicMissions()).isEmpty();
 		assertThat(result.todayMissions()).isEmpty();
-		verify(missionRepository).findDefaultMissions(memberId, scenarioId, date);
+		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 	}
 
 
@@ -132,7 +132,7 @@ class MissionServiceTest {
 		Long scenarioId = 1L;
 		LocalDate date = LocalDate.now();
 
-		when(missionRepository.findDefaultMissions(memberId, scenarioId, date)).thenReturn(
+		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, date)).thenReturn(
 			List.of());
 
 		// when & then
@@ -534,7 +534,8 @@ class MissionServiceTest {
 		List<Mission> groupedBasicMissions = List.of(mission);
 		List<Mission> groupedTodayMissions = List.of();
 
-		when(missionRepository.findDefaultMissions(any(Long.class), any(Long.class), any())).thenReturn(missionList);
+		when(missionRepository.findTodayAndFutureMissions(any(Long.class),
+			any(Long.class), any())).thenReturn(missionList);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.BASIC))
 			.thenReturn(groupedBasicMissions);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.TODAY))
@@ -547,7 +548,7 @@ class MissionServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.basicMissions()).isNotEmpty();
 		assertThat(result.todayMissions()).isEmpty();
-		verify(missionRepository).findDefaultMissions(any(Long.class), any(Long.class), any());
+		verify(missionRepository).findTodayAndFutureMissions(any(Long.class), any(Long.class), any());
 	}
 
 
@@ -569,7 +570,7 @@ class MissionServiceTest {
 		List<Mission> groupedBasicMissions = List.of();
 		List<Mission> groupedTodayMissions = List.of(mission);
 
-		when(missionRepository.findMissionsByDate(memberId, scenarioId, pastDate)).thenReturn(missionList);
+		when(missionRepository.findPastMissionsByDate(memberId, scenarioId, pastDate)).thenReturn(missionList);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.BASIC))
 			.thenReturn(groupedBasicMissions);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.TODAY))
@@ -582,7 +583,7 @@ class MissionServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.basicMissions()).isEmpty();
 		assertThat(result.todayMissions()).isNotEmpty();
-		verify(missionRepository).findMissionsByDate(memberId, scenarioId, pastDate);
+		verify(missionRepository).findPastMissionsByDate(memberId, scenarioId, pastDate);
 	}
 
 
@@ -604,7 +605,7 @@ class MissionServiceTest {
 		List<Mission> groupedBasicMissions = List.of();
 		List<Mission> groupedTodayMissions = List.of(mission);
 
-		when(missionRepository.findMissionsByDate(memberId, scenarioId, futureDate)).thenReturn(missionList);
+		when(missionRepository.findTodayAndFutureMissions(memberId, scenarioId, futureDate)).thenReturn(missionList);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.BASIC))
 			.thenReturn(groupedBasicMissions);
 		when(missionTypeGrouper.groupAndSortByType(missionList, MissionType.TODAY))
@@ -617,7 +618,7 @@ class MissionServiceTest {
 		assertThat(result).isNotNull();
 		assertThat(result.basicMissions()).isEmpty();
 		assertThat(result.todayMissions()).isNotEmpty();
-		verify(missionRepository).findMissionsByDate(memberId, scenarioId, futureDate);
+		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, futureDate);
 	}
 
 

--- a/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
@@ -11,11 +11,15 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,6 +27,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.entity.Member;
@@ -55,6 +61,7 @@ import com.und.server.scenario.util.OrderCalculator;
 import jakarta.persistence.EntityManager;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ScenarioServiceTest {
 
 	@InjectMocks
@@ -84,6 +91,17 @@ class ScenarioServiceTest {
 	@Mock
 	private NotificationEventPublisher notificationEventPublisher;
 
+	@Mock
+	private Clock clock;
+
+	@BeforeEach
+	void setUp() {
+		// Clock 설정
+		when(clock.withZone(ZoneId.of("Asia/Seoul"))).thenReturn(Clock.fixed(
+			LocalDate.of(2024, 1, 15).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant(),
+			ZoneId.of("Asia/Seoul")
+		));
+	}
 
 	@Test
 	void Given_memberId_When_FindScenarios_Then_ReturnScenarios() {

--- a/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
@@ -177,7 +177,7 @@ class ScenarioServiceTest {
 		);
 
 		// mock
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.of(scenario));
 		Mockito.when(notificationService.findNotificationDetails(notification)).thenReturn(notifDetail);
 		Mockito.when(missionTypeGrouper.groupAndSortByType(scenario.getMissions(), MissionType.BASIC))
@@ -202,7 +202,7 @@ class ScenarioServiceTest {
 		final Long memberId = 1L;
 		final Long scenarioId = 99L;
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.empty());
 
 		// when & then
@@ -219,7 +219,7 @@ class ScenarioServiceTest {
 		final Long scenarioId = 10L;
 
 		// 다른 사용자의 시나리오는 존재하지 않음 (권한 검증으로 인해)
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.empty());
 
 		// when & then
@@ -245,7 +245,7 @@ class ScenarioServiceTest {
 
 		TodayMissionRequest request = new TodayMissionRequest("Stretch");
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId, date))
 			.thenReturn(Optional.of(scenario));
 
 		scenarioService.addTodayMissionToScenario(memberId, scenarioId, request, date);
@@ -262,7 +262,7 @@ class ScenarioServiceTest {
 
 		TodayMissionRequest request = new TodayMissionRequest("Stretch");
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(requestMemberId, scenarioId))
+		Mockito.when(scenarioRepository.findTodayScenarioFetchByIdAndMemberId(requestMemberId, scenarioId, date))
 			.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() ->
@@ -457,7 +457,7 @@ class ScenarioServiceTest {
 
 		TodayMissionRequest request = new TodayMissionRequest("Past Mission");
 
-		given(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		given(scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId, pastDate))
 			.willReturn(Optional.of(scenario));
 		doThrow(new ServerException(ScenarioErrorResult.INVALID_TODAY_MISSION_DATE))
 			.when(missionService).addTodayMission(scenario, request, pastDate);
@@ -513,7 +513,7 @@ class ScenarioServiceTest {
 			.notificationCondition(condition)
 			.build();
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.of(oldScenario));
 		Mockito.doAnswer(invocation -> {
 			Notification target = invocation.getArgument(0);
@@ -698,13 +698,14 @@ class ScenarioServiceTest {
 			.notification(notification)
 			.build();
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findNotificationFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.of(scenario));
 
 		// when
 		scenarioService.deleteScenarioWithAllMissions(memberId, scenarioId);
 
 		// then
+		verify(missionService).deleteMissions(scenarioId);
 		verify(notificationService).deleteNotification(notification);
 		verify(scenarioRepository).delete(scenario);
 		verify(notificationEventPublisher).publishDeleteEvent(eq(memberId), eq(scenarioId), eq(true));
@@ -730,7 +731,7 @@ class ScenarioServiceTest {
 			.notificationCondition(null)
 			.build();
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.empty());
 
 		// when & then
@@ -767,7 +768,7 @@ class ScenarioServiceTest {
 		Long memberId = 1L;
 		Long scenarioId = 99L;
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findNotificationFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.empty());
 
 		// when & then
@@ -812,7 +813,7 @@ class ScenarioServiceTest {
 			.notificationCondition(null)
 			.build();
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.of(oldScenario));
 
 		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
@@ -860,7 +861,7 @@ class ScenarioServiceTest {
 			.notificationCondition(null)
 			.build();
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.empty());
 
 		// when & then
@@ -977,7 +978,7 @@ class ScenarioServiceTest {
 			.build();
 
 		// mock - notificationInfo가 null인 경우
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findScenarioDetailFetchByIdAndMemberId(memberId, scenarioId))
 			.thenReturn(Optional.of(scenario));
 		Mockito.when(notificationService.findNotificationDetails(notification)).thenReturn(null);
 		Mockito.when(missionTypeGrouper.groupAndSortByType(scenario.getMissions(), MissionType.BASIC))
@@ -1066,7 +1067,7 @@ class ScenarioServiceTest {
 
 		TodayMissionRequest request = new TodayMissionRequest("Future Mission");
 
-		Mockito.when(scenarioRepository.findFetchByIdAndMemberId(memberId, scenarioId))
+		Mockito.when(scenarioRepository.findTodayScenarioFetchByIdAndMemberId(memberId, scenarioId, futureDate))
 			.thenReturn(Optional.of(scenario));
 
 		// when

--- a/src/test/java/com/und/server/scenario/util/MissionTypeGrouperTest.java
+++ b/src/test/java/com/und/server/scenario/util/MissionTypeGrouperTest.java
@@ -51,7 +51,7 @@ class MissionTypeGrouperTest {
 	@Test
 	void Given_TodayMissions_When_GroupAndSort_Then_ReturnReverseSortedList() {
 		// given
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.of(2024, 1, 15, 12, 0);
 
 		Mission m1 = Mission.builder()
 			.missionOrder(null)

--- a/src/test/java/com/und/server/scenario/util/MissionValidatorTest.java
+++ b/src/test/java/com/und/server/scenario/util/MissionValidatorTest.java
@@ -27,8 +27,8 @@ class MissionValidatorTest {
 	@Test
 	void Given_TodayDate_When_ValidateTodayMissionDateRange_Then_NoException() {
 		// given
-		LocalDate today = LocalDate.now();
-		LocalDate requestDate = LocalDate.now();
+		LocalDate today = LocalDate.of(2024, 1, 15);
+		LocalDate requestDate = LocalDate.of(2024, 1, 15);
 
 		// when & then
 		assertDoesNotThrow(() -> missionValidator.validateTodayMissionDateRange(today, requestDate));
@@ -37,8 +37,8 @@ class MissionValidatorTest {
 	@Test
 	void Given_FutureDate_When_ValidateTodayMissionDateRange_Then_NoException() {
 		// given
-		LocalDate today = LocalDate.now();
-		LocalDate futureDate = LocalDate.now().plusDays(1);
+		LocalDate today = LocalDate.of(2024, 1, 15);
+		LocalDate futureDate = LocalDate.of(2024, 1, 16);
 
 		// when & then
 		assertDoesNotThrow(() -> missionValidator.validateTodayMissionDateRange(today, futureDate));
@@ -47,8 +47,8 @@ class MissionValidatorTest {
 	@Test
 	void Given_PastDate_When_ValidateTodayMissionDateRange_Then_ThrowException() {
 		// given
-		LocalDate today = LocalDate.now();
-		LocalDate pastDate = LocalDate.now().minusDays(1);
+		LocalDate today = LocalDate.of(2024, 1, 15);
+		LocalDate pastDate = LocalDate.of(2024, 1, 14);
 
 		// when & then
 		assertThatThrownBy(() -> missionValidator.validateTodayMissionDateRange(today, pastDate))

--- a/src/test/java/com/und/server/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/und/server/weather/controller/WeatherControllerTest.java
@@ -56,7 +56,7 @@ class WeatherControllerTest {
 			WeatherType.SUNNY, FineDustType.GOOD, UvType.LOW
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -81,7 +81,7 @@ class WeatherControllerTest {
 			WeatherType.RAIN, FineDustType.NORMAL, UvType.NORMAL
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -106,7 +106,7 @@ class WeatherControllerTest {
 			WeatherType.CLOUDY, FineDustType.BAD, UvType.HIGH
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -130,7 +130,7 @@ class WeatherControllerTest {
 			WeatherType.SNOW, FineDustType.GOOD, UvType.VERY_LOW
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -155,7 +155,7 @@ class WeatherControllerTest {
 			WeatherType.SUNNY, FineDustType.GOOD, UvType.VERY_HIGH
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -180,7 +180,7 @@ class WeatherControllerTest {
 			WeatherType.CLOUDY, FineDustType.NORMAL, UvType.LOW
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then
@@ -205,7 +205,7 @@ class WeatherControllerTest {
 			WeatherType.SNOW, FineDustType.VERY_BAD, UvType.VERY_HIGH
 		);
 
-		given(weatherService.getWeatherInfo((request), (date)))
+		given(weatherService.getWeatherInfo((request), (date), "Asia/Seoul"))
 			.willReturn(expectedResponse);
 
 		// when & then


### PR DESCRIPTION
### ✅ PR 타입
- [x] feat: 새로운 기능 추가


### 🪾 반영 브랜치
feat/#72-scenario-backup -> dev

### ✨ 변경 사항
시나리오 미션 백업, DEFAULT 미션 체크상태 초기화, 기간 만료 백업 미션 삭제

### 💯 테스트 결과
```
 kimsuyeon  ~/Documents/beforegoing-server   feat/#73-scenario-backup ±  ./gradlew clean check test  
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-09-01T19:20:12.773+09:00  INFO 63289 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///Users/kimsuyeon/Documents/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 27s
10 actionable tasks: 10 executed
 kimsuyeon  ~/Documents/beforegoing-server   feat/#73-scenario-backup  

```

### 📂 관련 이슈
#73

### 👀 리뷰어에게


- 스케줄러 사용을 위해 Application 클래스에 @EnableScheduling 어노테이션을 추가했습니다.
- 미션 백업, 체크 상태 초기화, 기간 만료 미션 삭제는 특정 시각에 주기적으로 실행되어야 하는 로직이므로 스케줄러로 구현했습니다.

---
### runDailyBackupJob 스케줄러
- 매일 00시 자정에 실행됩니다.
1. useDate가 null인 BASIC 미션을 어제 날짜로 백업합니다.
2. useDate가 null인 BASIC 미션의 체크 상태를 false로 초기화합니다

### runExpiredMissionCleanupJob 스케줄러
- 매일 01시에 실행됩니다.
1. 보관 기간이 만료된 1개월 전 미션(BASIC, TODAY)을 삭제합니다.

---

- 미션은 BASIC과 TODAY 두 종류가 있습니다.
- TODAY는 특정 날짜에만 적용되는 미션이므로 useDate가 해당 날짜로 저장되며, 백업이나 리셋 대상에는 포함되지 않습니다.
- BASIC은 default 미션과 백업 미션으로 나뉩니다.
    - default BASIC: 시나리오를 추가하거나 수정할 때 생성되며 오늘 보여줄 데이터로 useDate는 null입니다.
    - 백업 BASIC: 스케줄러에 의해 과거 날짜로 복제된 데이터입니다.


조회 일자에 따라 다음 조건으로 미션을 조회하면 됩니다.

- 오늘: useDate가 null 또는 오늘 날짜인 미션
    - null → default BASIC
    - 오늘 날짜 → TODAY
        
- 미래: useDate가 null 또는 미래 날짜인 미션
    - null → default BASIC
    - 미래 날짜 → TODAY
        
- 과거: useDate가 과거 날짜인 미션
    - 과거 날짜 -> 해당 날짜의 BASIC 백업 미션, TODAY 미션

---
- 스케줄러는 대량 데이터를 다뤄야 하므로 JPA 대신 네이티브 쿼리로 직접 처리했습니다.
- 백업 및 만료 삭제 쿼리는 MySQL 네이티브 쿼리 기반으로 작성했습니다.
- 로컬 환경은 H2라서 처음에는 동작하지 않을 거라 예상했는데 호환이 되는 거 같습니다!
- 로컬 RDB를 로컬 MySQL로 바꿔 테스트해보았는데 정상적으로 동작하는 것 확인했습니다.

---
### 추가 변경 사항

- CRUD 로직에서 시나리오를 가져오는 쿼리에서 백업 미션까지 일괄적으로 받아오는 이슈가 있어 쿼리를 수정했습니다.

- 미래를 조회할때 TODAY 미션을 띄우는 부분만 동적으로 미션리스트를 띄우면 될 거 라고 생각했는데, 과거에서 바로 미래로 조회할 경우 BASIC 미션이 과거 기준으로 고정되어 불일치가 일어날거 같아 조회 쿼리만 수정했습니다.
	- **오늘 → 미래** 이동할 때: BASIC은 그대로 두고, TODAY만 바꿔주면 됨.
	- **과거 → 미래** 이동할 때: BASIC이 과거 기준 데이터였으니, 미래 기준에서는 BASIC도 달라져야 함. = 불일치
	
	결론적으로 미래 조회도 BASIC 미션을 반환합니다. 오늘/미래 조회 쿼리가 동일하고 과거만 다르게 처리합니다.

- 시나리오 삭제 시 미션 삭제를 JPA 고아 객체 옵션으로 처리하지 않고, 쿼리로 일괄 삭제하도록 변경했습니다.
고아 객체 옵션을 사용하면 시나리오 삭제 시 연관된 미션이 한 번에 삭제될 것으로 생각했는데, 실제로는 미션마다 개별 delete 쿼리가 날려지더라고요.

```
Hibernate: delete from mission where id=? 
Hibernate: delete from mission where id=? 
Hibernate: delete from mission where id=? 
Hibernate: delete from mission where id=? 
Hibernate: delete from mission where id=?
```
성능에 큰 문제가 없을 거 같지만 scenarioId를 FK로 참조하는 미션들을 일괄 삭제 쿼리로 처리하도록 수정했습니다.

+
# 추가 구현할 사항
### 미래 BASIC 미션 체크 반영
미래 BASIC 체크는 고려하지않아서 머지가 되면 추가 구현할 생각입니다!
체크 상태 변경 api는 체크하는 mission_id + date를 같이 받고, 만약 date가 미래일 경우에는 체크상태를 저장한 row만 따로 생성할 생각입니다.
Mission 엔티티에 parent_mission_id 컬럼을 추가하여, 만약 사용자가 미래에 mission_id가 3인 미션의 체크상태를변경하려 하면,
- parent_mission_id = 3
- use_date = 미래 날짜
- is_checked = true
로 저장하여

미래 데이터를 조회할때 parent_mission_id가 있는 mission의 경우는 체크로 보여주면 될 거 같아요.
백업시에도 만약 parent_mission_id가 있을경우 해당 row의 is_checked로 반영하면 될 거 같습니다!

더 좋은 솔루션이 있다면 말씀해주세요!
