### PR TITLE
Feat/#100 future basic missio check

### DIFF
--- a/src/main/java/com/und/server/common/config/AsyncConfig.java
+++ b/src/main/java/com/und/server/common/config/AsyncConfig.java
@@ -1,9 +1,32 @@
 package com.und.server.common.config;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
+
+	@Bean
+	@Primary
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);
+		executor.setMaxPoolSize(4);
+		executor.setQueueCapacity(10);
+		executor.setThreadNamePrefix("async-");
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+		executor.setKeepAliveSeconds(60);
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(30);
+		executor.initialize();
+		return executor;
+	}
+
 }

--- a/src/main/java/com/und/server/scenario/controller/MissionController.java
+++ b/src/main/java/com/und/server/scenario/controller/MissionController.java
@@ -86,9 +86,10 @@ public class MissionController {
 	public ResponseEntity<Void> updateMissionCheck(
 		@AuthMember final Long memberId,
 		@PathVariable final Long missionId,
-		@RequestBody @NotNull final Boolean isChecked
+		@RequestBody @NotNull final Boolean isChecked,
+		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") final LocalDate date
 	) {
-		missionService.updateMissionCheck(memberId, missionId, isChecked);
+		missionService.updateMissionCheck(memberId, missionId, isChecked, date);
 
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}

--- a/src/main/java/com/und/server/scenario/dto/response/MissionGroupResponse.java
+++ b/src/main/java/com/und/server/scenario/dto/response/MissionGroupResponse.java
@@ -46,4 +46,14 @@ public record MissionGroupResponse(
 			.build();
 	}
 
+	public static MissionGroupResponse futureFrom(
+		final Long scenarioId, final List<MissionResponse> futureBasic, final List<Mission> today
+	) {
+		return MissionGroupResponse.builder()
+			.scenarioId(scenarioId)
+			.basicMissions(futureBasic)
+			.todayMissions(MissionResponse.listFrom(today))
+			.build();
+	}
+
 }

--- a/src/main/java/com/und/server/scenario/dto/response/MissionResponse.java
+++ b/src/main/java/com/und/server/scenario/dto/response/MissionResponse.java
@@ -36,6 +36,15 @@ public record MissionResponse(
 			.build();
 	}
 
+	public static MissionResponse fromWithOverride(final Mission mission, final Boolean overrideChecked) {
+		return MissionResponse.builder()
+			.missionId(mission.getId())
+			.content(mission.getContent())
+			.isChecked(overrideChecked)
+			.missionType(mission.getMissionType())
+			.build();
+	}
+
 	public static List<MissionResponse> listFrom(final List<Mission> missionList) {
 		if (missionList == null || missionList.isEmpty()) {
 			return new ArrayList<>();

--- a/src/main/java/com/und/server/scenario/entity/Mission.java
+++ b/src/main/java/com/und/server/scenario/entity/Mission.java
@@ -52,6 +52,9 @@ public class Mission extends BaseTimeEntity {
 	private Integer missionOrder;
 
 	@Column
+	private Long parentMissionId;
+
+	@Column
 	private LocalDate useDate;
 
 	@Enumerated(EnumType.STRING)
@@ -64,6 +67,17 @@ public class Mission extends BaseTimeEntity {
 
 	public void updateMissionOrder(final Integer missionOrder) {
 		this.missionOrder = missionOrder;
+	}
+
+	public Mission createFutureChildMission(final boolean isChecked, LocalDate future) {
+		return Mission.builder()
+			.scenario(this.scenario)
+			.content(this.content)
+			.isChecked(isChecked)
+			.parentMissionId(this.id)
+			.useDate(future)
+			.missionType(this.missionType)
+			.build();
 	}
 
 }

--- a/src/main/java/com/und/server/scenario/repository/MissionRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/MissionRepository.java
@@ -62,16 +62,16 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("""
 		UPDATE Mission p
-		   SET p.isChecked = COALESCE(
-		       (SELECT c.isChecked
-		          FROM Mission c
-		         WHERE c.parentMissionId = p.id
-		           AND c.useDate = :today
-		           AND c.missionType = 'BASIC'
-		       ), false
-		   )
-		 WHERE p.useDate IS NULL
-		   AND p.missionType = 'BASIC'
+			SET p.isChecked = COALESCE(
+				(SELECT c.isChecked
+				FROM Mission c
+				WHERE c.parentMissionId = p.id
+				AND c.useDate = :today
+				AND c.missionType = 'BASIC'
+				), false
+			)
+			WHERE p.useDate IS NULL
+				AND p.missionType = 'BASIC'
 		""")
 	int bulkResetBasicIsChecked(LocalDate today);
 

--- a/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
+++ b/src/main/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJob.java
@@ -35,9 +35,11 @@ public class ScenarioMissionDailyJob {
 
 		try {
 			int cloned = missionRepository.bulkCloneBasicToYesterday(yesterday);
-			int reset = missionRepository.bulkResetBasicIsChecked();
+			int reset = missionRepository.bulkResetBasicIsChecked(today);
+			int deleteChildBasic = missionRepository.deleteTodayChildBasics(today);
 
-			log.info("[MISSION DAILY] Daily Mission Job: cloned={}, reset={}", cloned, reset);
+			log.info("[MISSION DAILY] Daily Mission Job: cloned={}, reset={} deleteChildBasic={}",
+				cloned, reset, deleteChildBasic);
 		} catch (Exception e) {
 			log.error("[MISSION DAILY] Backup and reset failed, rolling back", e);
 			throw e;

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -172,13 +172,9 @@ public class MissionService {
 		missionValidator.validateMissionAccessibleMember(mission, memberId);
 
 		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(LocalDate.now(), date);
+
 		if (mission.getMissionType() == MissionType.BASIC && missionSearchType == MissionSearchType.FUTURE) {
-			Optional<Mission> futureMission = missionRepository.findByParentMissionIdAndUseDate(missionId, date);
-			if (futureMission.isPresent()) {
-				futureMission.get().updateCheckStatus(isChecked);
-				return;
-			}
-			missionRepository.save(mission.createFutureChildMission(isChecked, date));
+			updateFutureBasicMission(mission, missionId, isChecked, date);
 			return;
 		}
 
@@ -233,6 +229,24 @@ public class MissionService {
 			.toList();
 
 		return groupedBasicMissions;
+	}
+
+	private void updateFutureBasicMission(
+		final Mission mission,
+		final Long missionId,
+		final Boolean isChecked,
+		final LocalDate date
+	) {
+		Optional<Mission> futureMission = missionRepository.findByParentMissionIdAndUseDate(missionId, date);
+		if (futureMission.isPresent()) {
+			if (!isChecked) {
+				missionRepository.delete(futureMission.get());
+			} else {
+				futureMission.get().updateCheckStatus(isChecked);
+			}
+			return;
+		}
+		missionRepository.save(mission.createFutureChildMission(isChecked, date));
 	}
 
 }

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -174,7 +174,7 @@ public class MissionService {
 			LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul"))), date);
 
 		if (mission.getMissionType() == MissionType.BASIC && missionSearchType == MissionSearchType.FUTURE) {
-			updateFutureBasicMission(mission, missionId, isChecked, date);
+			updateFutureBasicMission(mission, isChecked, date);
 			return;
 		}
 		mission.updateCheckStatus(isChecked);
@@ -231,11 +231,10 @@ public class MissionService {
 
 	private void updateFutureBasicMission(
 		final Mission mission,
-		final Long missionId,
 		final Boolean isChecked,
 		final LocalDate date
 	) {
-		missionRepository.findByParentMissionIdAndUseDate(missionId, date)
+		missionRepository.findByParentMissionIdAndUseDate(mission.getId(), date)
 			.ifPresentOrElse(
 				future -> {
 					if (isChecked) {

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -220,15 +220,16 @@ public class MissionService {
 			.filter(m -> m.getParentMissionId() != null)
 			.collect(Collectors.toMap(Mission::getParentMissionId, m -> m));
 
-		groupedBasicMissions = groupedBasicMissions.stream()
+		List<Mission> parentMissions = new ArrayList<>();
+		groupedBasicMissions.stream()
 			.filter(m -> m.getParentMissionId() == null && m.getUseDate() == null)
-			.peek(tpl -> {
+			.forEach(tpl -> {
 				Mission overlay = overlayMap.get(tpl.getId());
 				tpl.updateCheckStatus(overlay != null && Boolean.TRUE.equals(overlay.getIsChecked()));
-			})
-			.toList();
+				parentMissions.add(tpl);
+			});
 
-		return groupedBasicMissions;
+		return parentMissions;
 	}
 
 	private void updateFutureBasicMission(

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -54,7 +54,7 @@ public class MissionService {
 		List<Mission> missions = getMissionsByDate(missionSearchType, memberId, scenarioId, date);
 
 		if (missions == null || missions.isEmpty()) {
-			return MissionGroupResponse.from(List.of(), List.of());
+			return MissionGroupResponse.from(scenarioId, List.of(), List.of());
 		}
 
 		List<Mission> groupedBasicMissions =

--- a/src/main/java/com/und/server/scenario/service/MissionService.java
+++ b/src/main/java/com/und/server/scenario/service/MissionService.java
@@ -47,7 +47,7 @@ public class MissionService {
 	) {
 		scenarioValidator.validateScenarioExists(scenarioId);
 
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul")));
 		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(today, date);
 
 		List<Mission> missions = getMissionsByDate(missionSearchType, memberId, scenarioId, date);
@@ -170,7 +170,8 @@ public class MissionService {
 			.orElseThrow(() -> new ServerException(ScenarioErrorResult.NOT_FOUND_MISSION));
 		missionValidator.validateMissionAccessibleMember(mission, memberId);
 
-		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(LocalDate.now(), date);
+		MissionSearchType missionSearchType = MissionSearchType.getMissionSearchType(
+			LocalDate.now(clock.withZone(ZoneId.of("Asia/Seoul"))), date);
 
 		if (mission.getMissionType() == MissionType.BASIC && missionSearchType == MissionSearchType.FUTURE) {
 			updateFutureBasicMission(mission, missionId, isChecked, date);

--- a/src/main/java/com/und/server/scenario/util/MissionTypeGroupSorter.java
+++ b/src/main/java/com/und/server/scenario/util/MissionTypeGroupSorter.java
@@ -30,7 +30,8 @@ public class MissionTypeGroupSorter {
 	private Comparator<Mission> getComparatorByType(final MissionType type) {
 		return switch (type) {
 
-			case BASIC -> Comparator.comparing(Mission::getMissionOrder);
+			case BASIC -> Comparator.comparing(Mission::getMissionOrder,
+				Comparator.nullsLast(Comparator.naturalOrder()));
 			case TODAY -> Comparator.comparing(Mission::getCreatedAt).reversed();
 
 			default -> throw new ServerException(ScenarioErrorResult.UNSUPPORTED_MISSION_TYPE);

--- a/src/main/resources/db/migration/V8__add_parent_mission_id.sql
+++ b/src/main/resources/db/migration/V8__add_parent_mission_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE mission
+    ADD COLUMN parent_mission_id BIGINT NULL;
+
+ALTER TABLE mission
+    ADD CONSTRAINT fk_mission_parent_mission
+        FOREIGN KEY (parent_mission_id) REFERENCES mission(id) ON DELETE CASCADE;

--- a/src/test/java/com/und/server/scenario/controller/MissionControllerTest.java
+++ b/src/test/java/com/und/server/scenario/controller/MissionControllerTest.java
@@ -170,14 +170,15 @@ class MissionControllerTest {
 		Long memberId = 1L;
 		Long missionId = 1L;
 		Boolean isChecked = true;
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		// when
-		ResponseEntity<Void> response = missionController.updateMissionCheck(memberId, missionId, isChecked);
+		ResponseEntity<Void> response = missionController.updateMissionCheck(memberId, missionId, isChecked, date);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 		assertThat(response.getBody()).isNull();
-		verify(missionService).updateMissionCheck(memberId, missionId, isChecked);
+		verify(missionService).updateMissionCheck(memberId, missionId, isChecked, date);
 	}
 
 
@@ -187,14 +188,15 @@ class MissionControllerTest {
 		Long memberId = 1L;
 		Long missionId = 1L;
 		Boolean isChecked = false;
+		LocalDate date = LocalDate.of(2024, 1, 15);
 
 		// when
-		ResponseEntity<Void> response = missionController.updateMissionCheck(memberId, missionId, isChecked);
+		ResponseEntity<Void> response = missionController.updateMissionCheck(memberId, missionId, isChecked, date);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
 		assertThat(response.getBody()).isNull();
-		verify(missionService).updateMissionCheck(memberId, missionId, isChecked);
+		verify(missionService).updateMissionCheck(memberId, missionId, isChecked, date);
 	}
 
 }

--- a/src/test/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJobTest.java
+++ b/src/test/java/com/und/server/scenario/scheduler/ScenarioMissionDailyJobTest.java
@@ -49,7 +49,7 @@ class ScenarioMissionDailyJobTest {
 	void Given_NormalCase_When_RunDailyBackupJob_Then_CloneAndResetCalled() {
 		// given
 		when(missionRepository.bulkCloneBasicToYesterday(any(LocalDate.class))).thenReturn(7);
-		when(missionRepository.bulkResetBasicIsChecked()).thenReturn(100);
+		when(missionRepository.bulkResetBasicIsChecked(any(LocalDate.class))).thenReturn(100);
 
 		// when
 		job.runDailyBackupJob();
@@ -57,7 +57,7 @@ class ScenarioMissionDailyJobTest {
 		// then
 		ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
 		verify(missionRepository).bulkCloneBasicToYesterday(dateCaptor.capture());
-		verify(missionRepository).bulkResetBasicIsChecked();
+		verify(missionRepository).bulkResetBasicIsChecked(any(LocalDate.class));
 
 		LocalDate captured = dateCaptor.getValue();
 		LocalDate expectedYesterday = LocalDate.of(2025, 8, 31);

--- a/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
@@ -114,9 +114,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, date);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isNotEmpty();
-		assertThat(result.todayMissions()).isNotEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isNotEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isNotEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 		verify(missionTypeGrouper).groupAndSortByType(missionList, MissionType.BASIC);
 		verify(missionTypeGrouper).groupAndSortByType(missionList, MissionType.TODAY);
@@ -137,9 +138,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, date);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 	}
 
@@ -157,9 +159,10 @@ class MissionServiceTest {
 		// when & then
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, date);
 
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isEmpty());
 	}
 
 
@@ -568,9 +571,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, nullDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isNotEmpty();
-		assertThat(result.todayMissions()).isEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isNotEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(any(Long.class), any(Long.class), any());
 	}
 
@@ -603,9 +607,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, pastDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isNotEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isNotEmpty());
 		verify(missionRepository).findPastMissionsByDate(memberId, scenarioId, pastDate);
 	}
 
@@ -638,9 +643,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, futureDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isNotEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isNotEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, futureDate);
 	}
 
@@ -729,9 +735,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, date);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 	}
 
@@ -749,9 +756,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, date);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).isEmpty();
-		assertThat(result.todayMissions()).isEmpty();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).isEmpty())
+			.satisfies(r -> assertThat(r.todayMissions()).isEmpty());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, date);
 	}
 
@@ -999,8 +1007,9 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, pastDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).hasSize(1);
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1));
 		verify(missionRepository).findPastMissionsByDate(memberId, scenarioId, pastDate);
 	}
 
@@ -1043,9 +1052,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, futureDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).hasSize(1);
-		assertThat(result.basicMissions().get(0).isChecked()).isTrue();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.basicMissions().get(0).isChecked()).isTrue());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, futureDate);
 	}
 
@@ -1079,9 +1089,10 @@ class MissionServiceTest {
 		MissionGroupResponse result = missionService.findMissionsByScenarioId(memberId, scenarioId, futureDate);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.basicMissions()).hasSize(1);
-		assertThat(result.basicMissions().get(0).isChecked()).isFalse();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.basicMissions().get(0).isChecked()).isFalse());
 		verify(missionRepository).findTodayAndFutureMissions(memberId, scenarioId, futureDate);
 	}
 
@@ -1164,10 +1175,11 @@ class MissionServiceTest {
 		MissionResponse response = MissionResponse.from(mission);
 
 		// then
-		assertThat(response.missionId()).isEqualTo(mission.getId());
-		assertThat(response.content()).isEqualTo(mission.getContent());
-		assertThat(response.isChecked()).isEqualTo(mission.getIsChecked());
-		assertThat(response.missionType()).isEqualTo(mission.getMissionType());
+		assertThat(response)
+			.satisfies(r -> assertThat(r.missionId()).isEqualTo(mission.getId()))
+			.satisfies(r -> assertThat(r.content()).isEqualTo(mission.getContent()))
+			.satisfies(r -> assertThat(r.isChecked()).isEqualTo(mission.getIsChecked()))
+			.satisfies(r -> assertThat(r.missionType()).isEqualTo(mission.getMissionType()));
 	}
 
 	@Test
@@ -1186,10 +1198,11 @@ class MissionServiceTest {
 		MissionResponse response = MissionResponse.fromWithOverride(mission, overrideChecked);
 
 		// then
-		assertThat(response.missionId()).isEqualTo(mission.getId());
-		assertThat(response.content()).isEqualTo(mission.getContent());
-		assertThat(response.isChecked()).isEqualTo(overrideChecked);
-		assertThat(response.missionType()).isEqualTo(mission.getMissionType());
+		assertThat(response)
+			.satisfies(r -> assertThat(r.missionId()).isEqualTo(mission.getId()))
+			.satisfies(r -> assertThat(r.content()).isEqualTo(mission.getContent()))
+			.satisfies(r -> assertThat(r.isChecked()).isEqualTo(overrideChecked))
+			.satisfies(r -> assertThat(r.missionType()).isEqualTo(mission.getMissionType()));
 	}
 
 	@Test
@@ -1215,9 +1228,10 @@ class MissionServiceTest {
 		List<MissionResponse> responseList = MissionResponse.listFrom(missionList);
 
 		// then
-		assertThat(responseList).hasSize(2);
-		assertThat(responseList.get(0).missionId()).isEqualTo(mission1.getId());
-		assertThat(responseList.get(1).missionId()).isEqualTo(mission2.getId());
+		assertThat(responseList)
+			.hasSize(2)
+			.satisfies(list -> assertThat(list.get(0).missionId()).isEqualTo(mission1.getId()))
+			.satisfies(list -> assertThat(list.get(1).missionId()).isEqualTo(mission2.getId()));
 	}
 
 	@Test
@@ -1267,10 +1281,11 @@ class MissionServiceTest {
 		MissionGroupResponse response = MissionGroupResponse.from(basicMissions, todayMissions);
 
 		// then
-		assertThat(response.basicMissions()).hasSize(1);
-		assertThat(response.todayMissions()).hasSize(1);
-		assertThat(response.basicMissions().get(0).missionId()).isEqualTo(basicMission.getId());
-		assertThat(response.todayMissions().get(0).missionId()).isEqualTo(todayMission.getId());
+		assertThat(response)
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.todayMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.basicMissions().get(0).missionId()).isEqualTo(basicMission.getId()))
+			.satisfies(r -> assertThat(r.todayMissions().get(0).missionId()).isEqualTo(todayMission.getId()));
 	}
 
 	@Test
@@ -1296,9 +1311,10 @@ class MissionServiceTest {
 		MissionGroupResponse response = MissionGroupResponse.from(scenarioId, basicMissions, todayMissions);
 
 		// then
-		assertThat(response.scenarioId()).isEqualTo(scenarioId);
-		assertThat(response.basicMissions()).hasSize(1);
-		assertThat(response.todayMissions()).hasSize(1);
+		assertThat(response)
+			.satisfies(r -> assertThat(r.scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.todayMissions()).hasSize(1));
 	}
 
 	@Test
@@ -1326,11 +1342,12 @@ class MissionServiceTest {
 			MissionGroupResponse.futureFrom(scenarioId, futureBasicResponses, todayMissions);
 
 		// then
-		assertThat(response.scenarioId()).isEqualTo(scenarioId);
-		assertThat(response.basicMissions()).hasSize(1);
-		assertThat(response.basicMissions().get(0).missionId()).isEqualTo(futureBasicResponse.missionId());
-		assertThat(response.todayMissions()).hasSize(1);
-		assertThat(response.todayMissions().get(0).missionId()).isEqualTo(todayMission.getId());
+		assertThat(response)
+			.satisfies(r -> assertThat(r.scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.basicMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.basicMissions().get(0).missionId()).isEqualTo(futureBasicResponse.missionId()))
+			.satisfies(r -> assertThat(r.todayMissions()).hasSize(1))
+			.satisfies(r -> assertThat(r.todayMissions().get(0).missionId()).isEqualTo(todayMission.getId()));
 	}
 
 }

--- a/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/MissionServiceTest.java
@@ -720,7 +720,7 @@ class MissionServiceTest {
 		verify(missionRepository).deleteByScenarioId(scenarioId);
 	}
 
-	// MissionService 누락 브랜치 커버리지를 위한 추가 테스트들
+
 	@Test
 	void Given_EmptyMissions_When_FindMissionsByScenarioId_Then_ReturnEmptyResponse() {
 		// given


### PR DESCRIPTION
### ✅ PR 타입
- [x] feat: 새로운 기능 추가

### 🪾 반영 브랜치
feat/#100-future-basic-mission-check -> dev

### ✨ 변경 사항
미래 미션 체크상태 반영

### 💯 테스트 결과
```
 kimsuyeon  ~/Documents/beforegoing-server   feat/#100-future-basic-missio-check  ./gradlew clean check test  
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-09-04T20:18:27.259+09:00  INFO 96080 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///Users/kimsuyeon/Documents/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 23s
10 actionable tasks: 10 executed
 kimsuyeon  ~/Documents/beforegoing-server   feat/#100-future-basic-missio-check  git status           
```

### 📂 관련 이슈
#100 

### 👀 리뷰어에게

### 주요 변경 사항

**오늘 미션 체크/리셋**
- 기존: 오늘 BASIC 체크상태 일괄 false
- 변경: 미래 체크 상태까지 반영하여 reset + 반영후 useDate가 오늘인 미래 데이터 삭제

**미래 미션 체크**
- `missionId + date`를 기반으로 처리
- date가 미래일 경우 → `parentMissionId = missionId`, `useDate = 미래 날짜`,`isChecked = true`로 새로운 row 생성

**미래 미션 리스트 출력**
- 기본(default) 미션 리스트를 기반으로
- 미래 미션의 체크 상태를 반영해 DTO 반환

**삭제/업데이트 시 처리**
- 시나리오 삭제 시: 해당 시나리오의 모든 미래 체크 상태 row 일괄 삭제
- 시나리오 업데이트 시: 삭제된 mission의 `id`를 `parentMissionId`로 가진 데이터 삭제
