### PR TITLE
Bug/#104 scenario

### DIFF
--- a/src/main/java/com/und/server/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/und/server/notification/controller/NotificationApiDocs.java
@@ -13,8 +13,40 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotNull;
 
 public interface NotificationApiDocs {
+
+	@Operation(summary = "Update Notification Active Status API")
+	@ApiResponses({
+			@ApiResponse(
+					responseCode = "204",
+					description = "Successfully updated notification active status",
+					content = @Content
+			),
+			@ApiResponse(
+					responseCode = "401",
+					description = "Unauthorized access",
+					content = @Content(
+							mediaType = "application/json",
+							schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(
+									name = "Unauthorized access",
+									value = """
+										{
+										  "code": "UNAUTHORIZED_ACCESS",
+										  "message": "Unauthorized access"
+										}
+										"""
+							)
+					)
+			)
+	})
+	ResponseEntity<Void> updateNotificationActive(
+		@Parameter(hidden = true) final Long memberId,
+		@Parameter(description = "Notification active status") @NotNull final Boolean isActive
+	);
+
 
 	@Operation(summary = "Get Scenario Notification List API")
 	@ApiResponses({

--- a/src/main/java/com/und/server/notification/controller/NotificationController.java
+++ b/src/main/java/com/und/server/notification/controller/NotificationController.java
@@ -3,7 +3,9 @@ package com.und.server.notification.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,8 +14,10 @@ import com.und.server.auth.filter.AuthMember;
 import com.und.server.notification.dto.response.ScenarioNotificationListResponse;
 import com.und.server.notification.dto.response.ScenarioNotificationResponse;
 import com.und.server.notification.service.NotificationCacheService;
+import com.und.server.notification.service.NotificationService;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,7 +25,20 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1")
 public class NotificationController implements NotificationApiDocs {
 
+	private final NotificationService notificationService;
 	private final NotificationCacheService notificationCacheService;
+
+
+	@Override
+	@PatchMapping("notifications/active")
+	public ResponseEntity<Void> updateNotificationActive(
+		@AuthMember final Long memberId,
+		@RequestBody @NotNull final Boolean isActive
+	) {
+		notificationService.updateNotificationActiveStatus(memberId, isActive);
+
+		return ResponseEntity.noContent().build();
+	}
 
 
 	@Override

--- a/src/main/java/com/und/server/notification/entity/Notification.java
+++ b/src/main/java/com/und/server/notification/entity/Notification.java
@@ -56,6 +56,14 @@ public class Notification extends BaseTimeEntity {
 		return days.size() == 7;
 	}
 
+	public boolean hasNotificationCondition() {
+		return notificationMethodType != null && daysOfWeek != null;
+	}
+
+	public void updateActive(Boolean isActive) {
+		this.isActive = isActive;
+	}
+
 	public void activate(
 		final NotificationType notificationType,
 		final NotificationMethodType notificationMethodType,

--- a/src/main/java/com/und/server/notification/event/ActiveUpdateEvent.java
+++ b/src/main/java/com/und/server/notification/event/ActiveUpdateEvent.java
@@ -1,0 +1,8 @@
+package com.und.server.notification.event;
+
+public record ActiveUpdateEvent(
+
+	Long memberId,
+	boolean isActive
+
+) { }

--- a/src/main/java/com/und/server/notification/event/ActiveUpdateEventListener.java
+++ b/src/main/java/com/und/server/notification/event/ActiveUpdateEventListener.java
@@ -1,0 +1,45 @@
+package com.und.server.notification.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.und.server.notification.service.NotificationCacheService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ActiveUpdateEventListener {
+
+	private final NotificationCacheService notificationCacheService;
+
+	@Async
+	@TransactionalEventListener
+	public void handleActiveUpdate(final ActiveUpdateEvent event) {
+		final Long memberId = event.memberId();
+		final boolean isActive = event.isActive();
+
+		try {
+			if (isActive) {
+				processWithNotification(memberId);
+			} else {
+				processWithoutNotification(memberId);
+			}
+		} catch (Exception e) {
+			log.error("Failed to process notification active update event due to an unexpected error: {}", event, e);
+			notificationCacheService.deleteMemberAllCache(memberId);
+		}
+	}
+
+	private void processWithNotification(Long memberId) {
+		notificationCacheService.refreshCacheFromDatabase(memberId);
+	}
+
+	private void processWithoutNotification(Long memberId) {
+		notificationCacheService.deleteMemberAllCache(memberId);
+	}
+
+}

--- a/src/main/java/com/und/server/notification/event/NotificationEventPublisher.java
+++ b/src/main/java/com/und/server/notification/event/NotificationEventPublisher.java
@@ -38,4 +38,10 @@ public class NotificationEventPublisher {
 		eventPublisher.publishEvent(event);
 	}
 
+	public void publishActiveUpdateEvent(final Long memberId, final boolean isActive) {
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, isActive);
+
+		eventPublisher.publishEvent(event);
+	}
+
 }

--- a/src/main/java/com/und/server/notification/service/NotificationCacheService.java
+++ b/src/main/java/com/und/server/notification/service/NotificationCacheService.java
@@ -154,7 +154,7 @@ public class NotificationCacheService {
 		return false;
 	}
 
-	private void refreshCacheFromDatabase(Long memberId) {
+	public void refreshCacheFromDatabase(Long memberId) {
 		List<ScenarioNotificationResponse> scenarioNotifications =
 			scenarioNotificationService.getScenarioNotifications(memberId);
 

--- a/src/main/java/com/und/server/scenario/controller/ScenarioApiDocs.java
+++ b/src/main/java/com/und/server/scenario/controller/ScenarioApiDocs.java
@@ -199,38 +199,11 @@ public interface ScenarioApiDocs {
 	@ApiResponses({
 			@ApiResponse(
 					responseCode = "201",
-					description = "Create Scenario successful",
-					content = @Content(
-							mediaType = "application/json",
-							schema = @Schema(implementation = MissionGroupResponse.class),
-							examples = @ExampleObject(
-									name = "Basic missions only",
-									value = """
-										{
-										  "scenarioId": 2,
-										  "basicMissions": [
-										    {
-										      "missionId": 3,
-										      "content": "Lock door",
-										      "isChecked": false,
-										      "missionType": "BASIC"
-										    },
-										    {
-										      "missionId": 4,
-										      "content": "Open door",
-										      "isChecked": false,
-										      "missionType": "BASIC"
-										    }
-										  ],
-										  "todayMissions": []
-										}
-										"""
-							)
-					)
+					description = "Create Scenario successful"
 			),
 			@ApiResponse(
 					responseCode = "400",
-					description = "Bad request - invalid parameters",
+					description = "Bad request",
 					content = @Content(
 							mediaType = "application/json",
 							schema = @Schema(implementation = ErrorResponse.class),
@@ -319,7 +292,7 @@ public interface ScenarioApiDocs {
 					)
 			)
 	})
-	ResponseEntity<MissionGroupResponse> addScenario(
+	ResponseEntity<List<ScenarioResponse>> addScenario(
 			@Parameter(hidden = true) Long memberId,
 			@RequestBody(
 					description = "Scenario detail request",
@@ -380,15 +353,11 @@ public interface ScenarioApiDocs {
 	@ApiResponses({
 			@ApiResponse(
 					responseCode = "200",
-					description = "Update Scenario successful",
-					content = @Content(
-							mediaType = "application/json",
-							schema = @Schema(implementation = MissionGroupResponse.class)
-					)
+					description = "Update Scenario successful"
 			),
 			@ApiResponse(
 					responseCode = "400",
-					description = "Bad request - invalid parameters",
+					description = "Bad request",
 					content = @Content(
 							mediaType = "application/json",
 							schema = @Schema(implementation = ErrorResponse.class),
@@ -494,7 +463,7 @@ public interface ScenarioApiDocs {
 					)
 			)
 	})
-	ResponseEntity<MissionGroupResponse> updateScenario(
+	ResponseEntity<List<ScenarioResponse>> updateScenario(
 			@Parameter(hidden = true) Long memberId,
 			@Parameter(description = "Scenario ID") Long scenarioId,
 			@RequestBody(

--- a/src/main/java/com/und/server/scenario/controller/ScenarioController.java
+++ b/src/main/java/com/und/server/scenario/controller/ScenarioController.java
@@ -20,7 +20,6 @@ import com.und.server.auth.filter.AuthMember;
 import com.und.server.notification.constants.NotificationType;
 import com.und.server.scenario.dto.request.ScenarioDetailRequest;
 import com.und.server.scenario.dto.request.ScenarioOrderUpdateRequest;
-import com.und.server.scenario.dto.response.MissionGroupResponse;
 import com.und.server.scenario.dto.response.OrderUpdateResponse;
 import com.und.server.scenario.dto.response.ScenarioDetailResponse;
 import com.und.server.scenario.dto.response.ScenarioResponse;
@@ -66,28 +65,28 @@ public class ScenarioController implements ScenarioApiDocs {
 
 	@Override
 	@PostMapping("/scenarios")
-	public ResponseEntity<MissionGroupResponse> addScenario(
+	public ResponseEntity<List<ScenarioResponse>> addScenario(
 		@AuthMember final Long memberId,
 		@RequestBody @Valid final ScenarioDetailRequest scenarioRequest
 	) {
-		final MissionGroupResponse missionGroupResponse =
+		final List<ScenarioResponse> scenarios =
 			scenarioService.addScenario(memberId, scenarioRequest);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(missionGroupResponse);
+		return ResponseEntity.status(HttpStatus.CREATED).body(scenarios);
 	}
 
 
 	@Override
 	@PutMapping("/scenarios/{scenarioId}")
-	public ResponseEntity<MissionGroupResponse> updateScenario(
+	public ResponseEntity<List<ScenarioResponse>> updateScenario(
 		@AuthMember final Long memberId,
 		@PathVariable final Long scenarioId,
 		@RequestBody @Valid final ScenarioDetailRequest scenarioRequest
 	) {
-		MissionGroupResponse missionGroupResponse =
+		final List<ScenarioResponse> scenarios =
 			scenarioService.updateScenario(memberId, scenarioId, scenarioRequest);
 
-		return ResponseEntity.ok().body(missionGroupResponse);
+		return ResponseEntity.ok().body(scenarios);
 	}
 
 

--- a/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
+++ b/src/main/java/com/und/server/scenario/repository/ScenarioRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,6 +16,9 @@ import jakarta.validation.constraints.NotNull;
 public interface ScenarioRepository extends JpaRepository<Scenario, Long>, ScenarioRepositoryCustom {
 
 	Optional<Scenario> findByIdAndMemberId(@NotNull Long id, @NotNull Long memberId);
+
+	@EntityGraph(attributePaths = {"notification"})
+	List<Scenario> findByMemberId(Long memberId);
 
 	@Query("""
 		SELECT s FROM Scenario s

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -111,7 +111,7 @@ public class ScenarioService {
 
 		int order = orders.isEmpty()
 			? OrderCalculator.START_ORDER
-			: getValidScenarioOrder(Collections.max(orders), memberId, notificationType);
+			: getValidScenarioOrder(Collections.min(orders), memberId, notificationType);
 
 		Notification notification = notificationService.addNotification(
 			notificationRequest, scenarioDetailRequest.notificationCondition());
@@ -212,12 +212,12 @@ public class ScenarioService {
 
 
 	private int getValidScenarioOrder(
-		final int maxScenarioOrder,
+		final int minScenarioOrder,
 		final Long memberId,
 		final NotificationType notificationType
 	) {
 		try {
-			return orderCalculator.getOrder(maxScenarioOrder, null);
+			return orderCalculator.getOrder(null, minScenarioOrder);
 		} catch (ReorderRequiredException e) {
 			List<Scenario> scenarios =
 				scenarioRepository.findByMemberIdAndNotificationType(memberId, notificationType);

--- a/src/main/java/com/und/server/scenario/service/ScenarioService.java
+++ b/src/main/java/com/und/server/scenario/service/ScenarioService.java
@@ -222,7 +222,7 @@ public class ScenarioService {
 			List<Scenario> scenarios =
 				scenarioRepository.findByMemberIdAndNotificationType(memberId, notificationType);
 
-			return orderCalculator.getMaxOrderAfterReorder(scenarios);
+			return orderCalculator.getMinOrderAfterReorder(scenarios);
 		}
 	}
 

--- a/src/main/java/com/und/server/scenario/util/OrderCalculator.java
+++ b/src/main/java/com/und/server/scenario/util/OrderCalculator.java
@@ -57,16 +57,16 @@ public class OrderCalculator {
 	}
 
 
-	public Integer getMaxOrderAfterReorder(final List<Scenario> scenarios) {
+	public Integer getMinOrderAfterReorder(final List<Scenario> scenarios) {
 		if (scenarios.isEmpty()) {
 			return START_ORDER;
 		}
 		scenarios.sort(Comparator.comparing(Scenario::getScenarioOrder));
 
 		assignSequentialOrders(scenarios);
-		Scenario lastScenario = scenarios.get(scenarios.size() - 1);
+		Scenario firstScenario = scenarios.get(0);
 
-		return calculateLastOrder(lastScenario.getScenarioOrder());
+		return calculateStartOrder(firstScenario.getScenarioOrder());
 	}
 
 

--- a/src/test/java/com/und/server/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/und/server/notification/controller/NotificationControllerTest.java
@@ -20,6 +20,7 @@ import com.und.server.notification.dto.response.ScenarioNotificationResponse;
 import com.und.server.notification.exception.NotificationCacheErrorResult;
 import com.und.server.notification.exception.NotificationCacheException;
 import com.und.server.notification.service.NotificationCacheService;
+import com.und.server.notification.service.NotificationService;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationControllerTest {
@@ -29,6 +30,9 @@ class NotificationControllerTest {
 
 	@Mock
 	private NotificationCacheService notificationCacheService;
+
+	@Mock
+	private NotificationService notificationService;
 
 	private final Long memberId = 1L;
 	private final Long scenarioId = 10L;
@@ -212,6 +216,52 @@ class NotificationControllerTest {
 		assertThat(response.getBody().scenarioId()).isEqualTo(differentScenarioId);
 		assertThat(response.getBody().scenarioName()).isEqualTo("다른 루틴");
 		verify(notificationCacheService).getSingleScenarioNotificationCache(memberId, differentScenarioId);
+	}
+
+
+	@Test
+	void Given_ValidRequest_When_UpdateNotificationActive_Then_ReturnNoContent() {
+		// given
+		Boolean isActive = true;
+
+		// when
+		ResponseEntity<Void> response = notificationController.updateNotificationActive(memberId, isActive);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		assertThat(response.getBody()).isNull();
+		verify(notificationService).updateNotificationActiveStatus(memberId, isActive);
+	}
+
+
+	@Test
+	void Given_ValidRequestWithFalse_When_UpdateNotificationActive_Then_ReturnNoContent() {
+		// given
+		Boolean isActive = false;
+
+		// when
+		ResponseEntity<Void> response = notificationController.updateNotificationActive(memberId, isActive);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		assertThat(response.getBody()).isNull();
+		verify(notificationService).updateNotificationActiveStatus(memberId, isActive);
+	}
+
+
+	@Test
+	void Given_DifferentMemberId_When_UpdateNotificationActive_Then_ReturnNoContent() {
+		// given
+		Long differentMemberId = 2L;
+		Boolean isActive = true;
+
+		// when
+		ResponseEntity<Void> response = notificationController.updateNotificationActive(differentMemberId, isActive);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		assertThat(response.getBody()).isNull();
+		verify(notificationService).updateNotificationActiveStatus(differentMemberId, isActive);
 	}
 
 }

--- a/src/test/java/com/und/server/notification/event/ActiveUpdateEventListenerTest.java
+++ b/src/test/java/com/und/server/notification/event/ActiveUpdateEventListenerTest.java
@@ -1,0 +1,116 @@
+package com.und.server.notification.event;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.und.server.notification.service.NotificationCacheService;
+
+@ExtendWith(MockitoExtension.class)
+class ActiveUpdateEventListenerTest {
+
+	@InjectMocks
+	private ActiveUpdateEventListener activeUpdateEventListener;
+
+	@Mock
+	private NotificationCacheService notificationCacheService;
+
+	private final Long memberId = 1L;
+
+
+	@Test
+	void Given_ActiveUpdateEventWithTrue_When_HandleActiveUpdate_Then_RefreshCacheFromDatabase() {
+		// given
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, true);
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService).refreshCacheFromDatabase(memberId);
+	}
+
+
+	@Test
+	void Given_ActiveUpdateEventWithFalse_When_HandleActiveUpdate_Then_DeleteMemberAllCache() {
+		// given
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, false);
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService).deleteMemberAllCache(memberId);
+	}
+
+
+	@Test
+	void Given_ActiveUpdateEventWithDifferentMemberId_When_HandleActiveUpdate_Then_RefreshCacheFromDatabase() {
+		// given
+		Long differentMemberId = 2L;
+		ActiveUpdateEvent event = new ActiveUpdateEvent(differentMemberId, true);
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService).refreshCacheFromDatabase(differentMemberId);
+	}
+
+
+	@Test
+	void Given_ActiveUpdateEventWithDifferentMemberIdAndFalse_When_HandleActiveUpdate_Then_DeleteMemberAllCache() {
+		// given
+		Long differentMemberId = 3L;
+		ActiveUpdateEvent event = new ActiveUpdateEvent(differentMemberId, false);
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService).deleteMemberAllCache(differentMemberId);
+	}
+
+
+	@Test
+	void Given_ExceptionOccursWhenActiveTrue_When_HandleActiveUpdate_Then_DeleteMemberAllCache() {
+		// given
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, true);
+
+		doThrow(new RuntimeException("Cache refresh failed"))
+			.when(notificationCacheService).refreshCacheFromDatabase(anyLong());
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService).refreshCacheFromDatabase(memberId);
+		verify(notificationCacheService).deleteMemberAllCache(memberId);
+	}
+
+
+	@Test
+	void Given_ExceptionOccursWhenActiveFalse_When_HandleActiveUpdate_Then_DeleteMemberAllCache() {
+		// given
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, false);
+
+		doAnswer(invocation -> {
+			throw new RuntimeException("Cache delete failed");
+		}).doNothing().when(notificationCacheService).deleteMemberAllCache(anyLong());
+
+		// when
+		activeUpdateEventListener.handleActiveUpdate(event);
+
+		// then
+		verify(notificationCacheService, times(2)).deleteMemberAllCache(memberId);
+	}
+
+}

--- a/src/test/java/com/und/server/notification/event/ActiveUpdateEventTest.java
+++ b/src/test/java/com/und/server/notification/event/ActiveUpdateEventTest.java
@@ -1,0 +1,101 @@
+package com.und.server.notification.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ActiveUpdateEventTest {
+
+	private final Long memberId = 1L;
+
+
+	@Test
+	void Given_ValidMemberIdAndActiveTrue_When_CreateActiveUpdateEvent_Then_CreateEventWithCorrectValues() {
+		// given
+		boolean isActive = true;
+
+		// when
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, isActive);
+
+		// then
+		assertThat(event.memberId()).isEqualTo(memberId);
+		assertThat(event.isActive()).isTrue();
+	}
+
+
+	@Test
+	void Given_ValidMemberIdAndActiveFalse_When_CreateActiveUpdateEvent_Then_CreateEventWithCorrectValues() {
+		// given
+		boolean isActive = false;
+
+		// when
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, isActive);
+
+		// then
+		assertThat(event.memberId()).isEqualTo(memberId);
+		assertThat(event.isActive()).isFalse();
+	}
+
+
+	@Test
+	void Given_DifferentMemberId_When_CreateActiveUpdateEvent_Then_CreateEventWithCorrectValues() {
+		// given
+		Long differentMemberId = 2L;
+		boolean isActive = true;
+
+		// when
+		ActiveUpdateEvent event = new ActiveUpdateEvent(differentMemberId, isActive);
+
+		// then
+		assertThat(event.memberId()).isEqualTo(differentMemberId);
+		assertThat(event.isActive()).isTrue();
+	}
+
+
+	@Test
+	void Given_SameValues_When_CreateTwoActiveUpdateEvents_Then_EventsAreEqual() {
+		// given
+		boolean isActive = true;
+
+		// when
+		ActiveUpdateEvent event1 = new ActiveUpdateEvent(memberId, isActive);
+		ActiveUpdateEvent event2 = new ActiveUpdateEvent(memberId, isActive);
+
+		// then
+		assertThat(event1).isEqualTo(event2);
+		assertThat(event1.hashCode()).isEqualTo(event2.hashCode());
+	}
+
+
+	@Test
+	void Given_DifferentValues_When_CreateTwoActiveUpdateEvents_Then_EventsAreNotEqual() {
+		// given
+		boolean isActive1 = true;
+		boolean isActive2 = false;
+
+		// when
+		ActiveUpdateEvent event1 = new ActiveUpdateEvent(memberId, isActive1);
+		ActiveUpdateEvent event2 = new ActiveUpdateEvent(memberId, isActive2);
+
+		// then
+		assertThat(event1).isNotEqualTo(event2);
+		assertThat(event1.hashCode()).isNotEqualTo(event2.hashCode());
+	}
+
+
+	@Test
+	void Given_ActiveUpdateEvent_When_ToString_Then_ReturnStringRepresentation() {
+		// given
+		boolean isActive = true;
+		ActiveUpdateEvent event = new ActiveUpdateEvent(memberId, isActive);
+
+		// when
+		String toString = event.toString();
+
+		// then
+		assertThat(toString).contains("ActiveUpdateEvent");
+		assertThat(toString).contains("memberId=" + memberId);
+		assertThat(toString).contains("isActive=" + isActive);
+	}
+
+}

--- a/src/test/java/com/und/server/notification/event/NotificationEventPublisherTest.java
+++ b/src/test/java/com/und/server/notification/event/NotificationEventPublisherTest.java
@@ -163,4 +163,44 @@ class NotificationEventPublisherTest {
 		verify(eventPublisher).publishEvent(any(ScenarioDeleteEvent.class));
 	}
 
+
+	@Test
+	void Given_ValidMemberIdAndActiveTrue_When_PublishActiveUpdateEvent_Then_PublishActiveUpdateEvent() {
+		// given
+		boolean isActive = true;
+
+		// when
+		notificationEventPublisher.publishActiveUpdateEvent(memberId, isActive);
+
+		// then
+		verify(eventPublisher).publishEvent(any(ActiveUpdateEvent.class));
+	}
+
+
+	@Test
+	void Given_ValidMemberIdAndActiveFalse_When_PublishActiveUpdateEvent_Then_PublishActiveUpdateEvent() {
+		// given
+		boolean isActive = false;
+
+		// when
+		notificationEventPublisher.publishActiveUpdateEvent(memberId, isActive);
+
+		// then
+		verify(eventPublisher).publishEvent(any(ActiveUpdateEvent.class));
+	}
+
+
+	@Test
+	void Given_DifferentMemberId_When_PublishActiveUpdateEvent_Then_PublishActiveUpdateEvent() {
+		// given
+		Long differentMemberId = 2L;
+		boolean isActive = true;
+
+		// when
+		notificationEventPublisher.publishActiveUpdateEvent(differentMemberId, isActive);
+
+		// then
+		verify(eventPublisher).publishEvent(any(ActiveUpdateEvent.class));
+	}
+
 }

--- a/src/test/java/com/und/server/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/und/server/notification/service/NotificationServiceTest.java
@@ -102,10 +102,11 @@ class NotificationServiceTest {
 		Notification result = notificationService.addNotification(notificationInfo, conditionInfo);
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.getNotificationType()).isEqualTo(NotificationType.TIME);
-		assertThat(result.getNotificationMethodType()).isEqualTo(NotificationMethodType.PUSH);
-		assertThat(result.getIsActive()).isTrue();
+		assertThat(result)
+			.isNotNull()
+			.satisfies(r -> assertThat(r.getNotificationType()).isEqualTo(NotificationType.TIME))
+			.satisfies(r -> assertThat(r.getNotificationMethodType()).isEqualTo(NotificationMethodType.PUSH))
+			.satisfies(r -> assertThat(r.getIsActive()).isTrue());
 		verify(notificationRepository).save(any(Notification.class));
 		verify(notificationConditionSelector)
 			.addNotificationCondition(any(Notification.class), eq(conditionInfo));
@@ -138,9 +139,10 @@ class NotificationServiceTest {
 		notificationService.updateNotification(oldNotification, notificationInfo, conditionInfo);
 
 		// then
-		assertThat(oldNotification.getNotificationType()).isEqualTo(NotificationType.TIME);
-		assertThat(oldNotification.getNotificationMethodType()).isEqualTo(NotificationMethodType.ALARM);
-		assertThat(oldNotification.isActive()).isTrue();
+		assertThat(oldNotification)
+			.satisfies(n -> assertThat(n.getNotificationType()).isEqualTo(NotificationType.TIME))
+			.satisfies(n -> assertThat(n.getNotificationMethodType()).isEqualTo(NotificationMethodType.ALARM))
+			.satisfies(n -> assertThat(n.isActive()).isTrue());
 		verify(notificationConditionSelector)
 			.updateNotificationCondition(oldNotification, conditionInfo);
 	}
@@ -172,9 +174,10 @@ class NotificationServiceTest {
 		notificationService.updateNotification(oldNotification, notificationInfo, conditionInfo);
 
 		// then
-		assertThat(oldNotification.getNotificationType()).isEqualTo(NotificationType.LOCATION);
-		assertThat(oldNotification.getNotificationMethodType()).isEqualTo(NotificationMethodType.ALARM);
-		assertThat(oldNotification.isActive()).isTrue();
+		assertThat(oldNotification)
+			.satisfies(n -> assertThat(n.getNotificationType()).isEqualTo(NotificationType.LOCATION))
+			.satisfies(n -> assertThat(n.getNotificationMethodType()).isEqualTo(NotificationMethodType.ALARM))
+			.satisfies(n -> assertThat(n.isActive()).isTrue());
 		verify(notificationConditionSelector).deleteNotificationCondition(
 			NotificationType.TIME, oldNotification.getId());
 		verify(notificationConditionSelector)
@@ -201,8 +204,9 @@ class NotificationServiceTest {
 		notificationService.updateNotification(oldNotification, notificationRequest, null);
 
 		// then
-		assertThat(oldNotification.isActive()).isFalse();
-		assertThat(oldNotification.getNotificationMethodType()).isNull();
+		assertThat(oldNotification)
+			.satisfies(n -> assertThat(n.isActive()).isFalse())
+			.satisfies(n -> assertThat(n.getNotificationMethodType()).isNull());
 		verify(notificationConditionSelector)
 			.deleteNotificationCondition(NotificationType.TIME, oldNotification.getId());
 	}
@@ -228,8 +232,9 @@ class NotificationServiceTest {
 		Notification result = notificationService.addNotification(request, null);
 
 		// then
-		assertThat(result.getNotificationType()).isEqualTo(type);
-		assertThat(result.getIsActive()).isFalse();
+		assertThat(result)
+			.satisfies(r -> assertThat(r.getNotificationType()).isEqualTo(type))
+			.satisfies(r -> assertThat(r.getIsActive()).isFalse());
 		verify(notificationRepository).save(any(Notification.class));
 	}
 
@@ -273,9 +278,10 @@ class NotificationServiceTest {
 
 		// then
 		assertThat(result).isEqualTo(expectedInfo);
-		assertThat(notification.isEveryDay()).isTrue();
-		assertThat(notification.getDaysOfWeekOrdinalList()).hasSize(7);
-		assertThat(notification.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6);
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.isEveryDay()).isTrue())
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).hasSize(7))
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6));
 		verify(notificationConditionSelector).findNotificationCondition(notification);
 	}
 
@@ -302,9 +308,10 @@ class NotificationServiceTest {
 
 		// then
 		assertThat(result).isEqualTo(expectedInfo);
-		assertThat(notification.isEveryDay()).isFalse();
-		assertThat(notification.getDaysOfWeekOrdinalList()).hasSize(3);
-		assertThat(notification.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(0, 2, 4);
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse())
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).hasSize(3))
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(0, 2, 4));
 		verify(notificationConditionSelector).findNotificationCondition(notification);
 	}
 
@@ -331,8 +338,9 @@ class NotificationServiceTest {
 
 		// then
 		assertThat(result).isEqualTo(expectedInfo);
-		assertThat(notification.isEveryDay()).isFalse();
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse())
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty());
 		verify(notificationConditionSelector).findNotificationCondition(notification);
 	}
 
@@ -359,8 +367,9 @@ class NotificationServiceTest {
 
 		// then
 		assertThat(result).isEqualTo(expectedInfo);
-		assertThat(notification.isEveryDay()).isFalse();
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse())
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty());
 		verify(notificationConditionSelector).findNotificationCondition(notification);
 	}
 
@@ -381,9 +390,10 @@ class NotificationServiceTest {
 		notification.updateDaysOfWeekOrdinal(newDays);
 
 		// then
-		assertThat(notification.getDaysOfWeekOrdinalList()).hasSize(3);
-		assertThat(notification.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(1, 3, 5);
-		assertThat(notification.isEveryDay()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).hasSize(3))
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).containsExactlyInAnyOrder(1, 3, 5))
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse());
 	}
 
 
@@ -403,8 +413,9 @@ class NotificationServiceTest {
 		notification.updateDaysOfWeekOrdinal(newDays);
 
 		// then
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
-		assertThat(notification.isEveryDay()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty())
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse());
 	}
 
 
@@ -422,8 +433,9 @@ class NotificationServiceTest {
 		notification.updateDaysOfWeekOrdinal(null);
 
 		// then
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
-		assertThat(notification.isEveryDay()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty())
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse());
 	}
 
 
@@ -441,8 +453,9 @@ class NotificationServiceTest {
 		notification.updateDaysOfWeekOrdinal(List.of());
 
 		// then
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
-		assertThat(notification.isEveryDay()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty())
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse());
 	}
 
 
@@ -460,8 +473,9 @@ class NotificationServiceTest {
 		notification.updateDaysOfWeekOrdinal(List.of());
 
 		// then
-		assertThat(notification.getDaysOfWeekOrdinalList()).isEmpty();
-		assertThat(notification.isEveryDay()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getDaysOfWeekOrdinalList()).isEmpty())
+			.satisfies(n -> assertThat(n.isEveryDay()).isFalse());
 	}
 
 
@@ -479,8 +493,9 @@ class NotificationServiceTest {
 		notification.deactivate();
 
 		// then
-		assertThat(notification.getNotificationMethodType()).isNull();
-		assertThat(notification.isActive()).isFalse();
+		assertThat(notification)
+			.satisfies(n -> assertThat(n.getNotificationMethodType()).isNull())
+			.satisfies(n -> assertThat(n.isActive()).isFalse());
 	}
 
 

--- a/src/test/java/com/und/server/scenario/controller/ScenarioControllerTest.java
+++ b/src/test/java/com/und/server/scenario/controller/ScenarioControllerTest.java
@@ -19,7 +19,6 @@ import com.und.server.notification.constants.NotificationType;
 import com.und.server.notification.dto.request.NotificationRequest;
 import com.und.server.scenario.dto.request.ScenarioDetailRequest;
 import com.und.server.scenario.dto.request.ScenarioOrderUpdateRequest;
-import com.und.server.scenario.dto.response.MissionGroupResponse;
 import com.und.server.scenario.dto.response.OrderUpdateResponse;
 import com.und.server.scenario.dto.response.ScenarioDetailResponse;
 import com.und.server.scenario.dto.response.ScenarioResponse;
@@ -101,17 +100,19 @@ class ScenarioControllerTest {
 			.memo("새 시나리오 설명")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(expectedScenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(expectedScenarioId)
+				.scenarioName("새 시나리오")
+				.memo("새 시나리오 설명")
+				.build()
+		);
 
 		when(scenarioService.addScenario(memberId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response = scenarioController.addScenario(memberId, scenarioRequest);
+		ResponseEntity<List<ScenarioResponse>> response = scenarioController.addScenario(memberId, scenarioRequest);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -138,17 +139,19 @@ class ScenarioControllerTest {
 			.notificationCondition(null)
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(expectedScenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(expectedScenarioId)
+				.scenarioName("새 시나리오")
+				.memo("메모")
+				.build()
+		);
 
 		when(scenarioService.addScenario(memberId, request))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response = scenarioController.addScenario(memberId, request);
+		ResponseEntity<List<ScenarioResponse>> response = scenarioController.addScenario(memberId, request);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -175,17 +178,19 @@ class ScenarioControllerTest {
 			.notificationCondition(null)
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(scenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(scenarioId)
+				.scenarioName("수정 시나리오")
+				.memo("메모")
+				.build()
+		);
 
 		when(scenarioService.updateScenario(memberId, scenarioId, request))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response = scenarioController
+		ResponseEntity<List<ScenarioResponse>> response = scenarioController
 			.updateScenario(memberId, scenarioId, request);
 
 		// then
@@ -205,17 +210,19 @@ class ScenarioControllerTest {
 			.memo("빈 제목 시나리오")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(expectedScenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(expectedScenarioId)
+				.scenarioName("")
+				.memo("빈 제목 시나리오")
+				.build()
+		);
 
 		when(scenarioService.addScenario(memberId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response = scenarioController.addScenario(memberId, scenarioRequest);
+		ResponseEntity<List<ScenarioResponse>> response = scenarioController.addScenario(memberId, scenarioRequest);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -234,17 +241,19 @@ class ScenarioControllerTest {
 			.memo("수정된 시나리오 설명")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(scenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(scenarioId)
+				.scenarioName("수정된 시나리오")
+				.memo("수정된 시나리오 설명")
+				.build()
+		);
 
 		when(scenarioService.updateScenario(memberId, scenarioId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response =
+		ResponseEntity<List<ScenarioResponse>> response =
 			scenarioController.updateScenario(memberId, scenarioId, scenarioRequest);
 
 		// then
@@ -264,17 +273,19 @@ class ScenarioControllerTest {
 			.memo("수정된 빈 제목 시나리오")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(scenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(scenarioId)
+				.scenarioName("")
+				.memo("수정된 빈 제목 시나리오")
+				.build()
+		);
 
 		when(scenarioService.updateScenario(memberId, scenarioId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response =
+		ResponseEntity<List<ScenarioResponse>> response =
 			scenarioController.updateScenario(memberId, scenarioId, scenarioRequest);
 
 		// then
@@ -294,17 +305,19 @@ class ScenarioControllerTest {
 			.memo("긴 제목 시나리오")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(expectedScenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(expectedScenarioId)
+				.scenarioName("매우 긴 시나리오 제목입니다")
+				.memo("긴 제목 시나리오")
+				.build()
+		);
 
 		when(scenarioService.addScenario(memberId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response = scenarioController.addScenario(memberId, scenarioRequest);
+		ResponseEntity<List<ScenarioResponse>> response = scenarioController.addScenario(memberId, scenarioRequest);
 
 		// then
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -323,17 +336,19 @@ class ScenarioControllerTest {
 			.memo("긴 제목 수정 시나리오")
 			.build();
 
-		MissionGroupResponse expectedResponse = MissionGroupResponse.builder()
-			.scenarioId(scenarioId)
-			.basicMissions(List.of())
-			.todayMissions(null)
-			.build();
+		List<ScenarioResponse> expectedResponse = List.of(
+			ScenarioResponse.builder()
+				.scenarioId(scenarioId)
+				.scenarioName("매우 긴 수정된 시나리오 제목입니다")
+				.memo("긴 제목 수정 시나리오")
+				.build()
+		);
 
 		when(scenarioService.updateScenario(memberId, scenarioId, scenarioRequest))
 			.thenReturn(expectedResponse);
 
 		// when
-		ResponseEntity<MissionGroupResponse> response =
+		ResponseEntity<List<ScenarioResponse>> response =
 			scenarioController.updateScenario(memberId, scenarioId, scenarioRequest);
 
 		// then

--- a/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
+++ b/src/test/java/com/und/server/scenario/service/ScenarioServiceTest.java
@@ -150,9 +150,10 @@ class ScenarioServiceTest {
 
 		//then
 		assertNotNull(result);
-		assertThat(result.size()).isEqualTo(2);
-		assertThat(result.get(0).scenarioName()).isEqualTo("시나리오A");
-		assertThat(result.get(1).scenarioName()).isEqualTo("시나리오B");
+		assertThat(result)
+			.hasSize(2)
+			.satisfies(r -> assertThat(r.get(0).scenarioName()).isEqualTo("시나리오A"))
+			.satisfies(r -> assertThat(r.get(1).scenarioName()).isEqualTo("시나리오B"));
 	}
 
 
@@ -205,11 +206,14 @@ class ScenarioServiceTest {
 
 		// then
 		assertNotNull(response);
-		assertThat(response.scenarioId()).isEqualTo(scenarioId);
-		assertThat(response.notificationCondition()).isInstanceOf(TimeNotificationResponse.class);
-		TimeNotificationResponse detail = (TimeNotificationResponse) response.notificationCondition();
-		assertThat(detail.startHour()).isEqualTo(8);
-		assertThat(detail.startMinute()).isEqualTo(30);
+		assertThat(response)
+			.satisfies(r -> assertThat(r.scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.notificationCondition()).isInstanceOf(TimeNotificationResponse.class))
+			.satisfies(r -> {
+				TimeNotificationResponse detail = (TimeNotificationResponse) r.notificationCondition();
+				assertThat(detail.startHour()).isEqualTo(8);
+				assertThat(detail.startMinute()).isEqualTo(30);
+			});
 	}
 
 
@@ -384,17 +388,19 @@ class ScenarioServiceTest {
 
 		Scenario saved = scenarioCaptor.getValue();
 
-		assertThat(saved.getScenarioName()).isEqualTo("Morning");
-		assertThat(saved.getMemo()).isEqualTo("Routine");
-		assertThat(saved.getScenarioOrder()).isEqualTo(calculatedOrder);
-		assertThat(saved.getNotification()).isEqualTo(savedNotification);
-		assertThat(saved.getMember().getId()).isEqualTo(member.getId());
+		assertThat(saved)
+			.satisfies(s -> assertThat(s.getScenarioName()).isEqualTo("Morning"))
+			.satisfies(s -> assertThat(s.getMemo()).isEqualTo("Routine"))
+			.satisfies(s -> assertThat(s.getScenarioOrder()).isEqualTo(calculatedOrder))
+			.satisfies(s -> assertThat(s.getNotification()).isEqualTo(savedNotification))
+			.satisfies(s -> assertThat(s.getMember().getId()).isEqualTo(member.getId()));
 
-		assertThat(result).isNotNull();
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).scenarioId()).isEqualTo(1L);
-		assertThat(result.get(0).scenarioName()).isEqualTo("Morning");
-		assertThat(result.get(0).memo()).isEqualTo("Routine");
+		assertThat(result)
+			.isNotNull()
+			.hasSize(1)
+			.satisfies(r -> assertThat(r.get(0).scenarioId()).isEqualTo(1L))
+			.satisfies(r -> assertThat(r.get(0).scenarioName()).isEqualTo("Morning"))
+			.satisfies(r -> assertThat(r.get(0).memo()).isEqualTo("Routine"));
 	}
 
 
@@ -474,13 +480,12 @@ class ScenarioServiceTest {
 		verify(notificationEventPublisher).publishCreateEvent(eq(memberId), any(Scenario.class));
 
 		Scenario saved = captor.getValue();
-		// Note: saved.getScenarioOrder() might be 0 due to ArgumentCaptor behavior
-		// The actual order is verified through the returned result
-		assertThat(result).isNotNull();
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).scenarioId()).isEqualTo(1L);
-		assertThat(result.get(0).scenarioName()).isEqualTo("Morning");
-		assertThat(result.get(0).memo()).isEqualTo("Routine");
+		assertThat(result)
+			.isNotNull()
+			.hasSize(1)
+			.satisfies(r -> assertThat(r.get(0).scenarioId()).isEqualTo(1L))
+			.satisfies(r -> assertThat(r.get(0).scenarioName()).isEqualTo("Morning"))
+			.satisfies(r -> assertThat(r.get(0).memo()).isEqualTo("Routine"));
 	}
 
 	@Test
@@ -577,21 +582,24 @@ class ScenarioServiceTest {
 		List<ScenarioResponse> result = scenarioService.updateScenario(memberId, scenarioId, scenarioRequest);
 
 		// then
-		assertThat(oldScenario.getScenarioName()).isEqualTo("수정된 시나리오");
-		assertThat(oldScenario.getMemo()).isEqualTo("수정된 메모");
-		assertThat(oldScenario.getNotification().getNotificationType()).isEqualTo(notifRequest.notificationType());
-		assertThat(oldScenario.getNotification().getNotificationMethodType())
-			.isEqualTo(notifRequest.notificationMethodType());
-		assertThat(oldScenario.getNotification().isActive()).isTrue();
+		assertThat(oldScenario)
+			.satisfies(s -> assertThat(s.getScenarioName()).isEqualTo("수정된 시나리오"))
+			.satisfies(s -> assertThat(s.getMemo()).isEqualTo("수정된 메모"))
+			.satisfies(
+				s -> assertThat(s.getNotification().getNotificationType()).isEqualTo(notifRequest.notificationType()))
+			.satisfies(s -> assertThat(s.getNotification().getNotificationMethodType())
+				.isEqualTo(notifRequest.notificationMethodType()))
+			.satisfies(s -> assertThat(s.getNotification().isActive()).isTrue());
 		verify(notificationService).updateNotification(oldNotification, notifRequest, condition);
 		verify(missionService).updateBasicMission(oldScenario, List.of());
 		verify(notificationEventPublisher).publishUpdateEvent(eq(memberId), eq(oldScenario), eq(true));
 
-		assertThat(result).isNotNull();
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).scenarioId()).isEqualTo(scenarioId);
-		assertThat(result.get(0).scenarioName()).isEqualTo("수정할 시나리오");
-		assertThat(result.get(0).memo()).isEqualTo("수정할 메모");
+		assertThat(result)
+			.isNotNull()
+			.hasSize(1)
+			.satisfies(r -> assertThat(r.get(0).scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.get(0).scenarioName()).isEqualTo("수정할 시나리오"))
+			.satisfies(r -> assertThat(r.get(0).memo()).isEqualTo("수정할 메모"));
 	}
 
 
@@ -631,10 +639,11 @@ class ScenarioServiceTest {
 
 		// then
 		assertThat(scenario.getScenarioOrder()).isEqualTo(newOrder);
-		assertThat(response.isReorder()).isFalse();
-		assertThat(response.orderUpdates()).hasSize(1);
-		assertThat(response.orderUpdates().get(0).id()).isEqualTo(scenarioId);
-		assertThat(response.orderUpdates().get(0).newOrder()).isEqualTo(newOrder);
+		assertThat(response)
+			.satisfies(r -> assertThat(r.isReorder()).isFalse())
+			.satisfies(r -> assertThat(r.orderUpdates()).hasSize(1))
+			.satisfies(r -> assertThat(r.orderUpdates().get(0).id()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.orderUpdates().get(0).newOrder()).isEqualTo(newOrder));
 		verify(orderCalculator).getOrder(1000, 2000);
 	}
 
@@ -682,8 +691,9 @@ class ScenarioServiceTest {
 		OrderUpdateResponse response = scenarioService.updateScenarioOrder(memberId, scenarioId, orderRequest);
 
 		// then
-		assertThat(response.isReorder()).isTrue();
-		assertThat(response.orderUpdates()).hasSize(2);
+		assertThat(response)
+			.satisfies(r -> assertThat(r.isReorder()).isTrue())
+			.satisfies(r -> assertThat(r.orderUpdates()).hasSize(2));
 		verify(orderCalculator).reorder(anyList(), eq(scenarioId), eq(errorOrder));
 	}
 
@@ -874,17 +884,19 @@ class ScenarioServiceTest {
 		List<ScenarioResponse> result = scenarioService.updateScenario(memberId, scenarioId, scenarioRequest);
 
 		// then
-		assertThat(oldScenario.getScenarioName()).isEqualTo("수정된 시나리오");
-		assertThat(oldScenario.getMemo()).isEqualTo("수정된 메모");
+		assertThat(oldScenario)
+			.satisfies(s -> assertThat(s.getScenarioName()).isEqualTo("수정된 시나리오"))
+			.satisfies(s -> assertThat(s.getMemo()).isEqualTo("수정된 메모"));
 		verify(notificationService).updateNotification(oldNotification, notificationRequest, null);
 		verify(missionService).updateBasicMission(oldScenario, List.of());
 		verify(notificationEventPublisher).publishUpdateEvent(eq(memberId), eq(oldScenario), eq(false));
 
-		assertThat(result).isNotNull();
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).scenarioId()).isEqualTo(scenarioId);
-		assertThat(result.get(0).scenarioName()).isEqualTo("수정할 시나리오");
-		assertThat(result.get(0).memo()).isEqualTo("수정할 메모");
+		assertThat(result)
+			.isNotNull()
+			.hasSize(1)
+			.satisfies(r -> assertThat(r.get(0).scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.get(0).scenarioName()).isEqualTo("수정할 시나리오"))
+			.satisfies(r -> assertThat(r.get(0).memo()).isEqualTo("수정할 메모"));
 	}
 
 
@@ -1035,10 +1047,11 @@ class ScenarioServiceTest {
 
 		// then
 		assertNotNull(response);
-		assertThat(response.scenarioId()).isEqualTo(scenarioId);
-		assertThat(response.notification().isEveryDay()).isNull();
-		assertThat(response.notification().daysOfWeekOrdinal()).isNull();
-		assertThat(response.notificationCondition()).isNull();
+		assertThat(response)
+			.satisfies(r -> assertThat(r.scenarioId()).isEqualTo(scenarioId))
+			.satisfies(r -> assertThat(r.notification().isEveryDay()).isNull())
+			.satisfies(r -> assertThat(r.notification().daysOfWeekOrdinal()).isNull())
+			.satisfies(r -> assertThat(r.notificationCondition()).isNull());
 	}
 
 

--- a/src/test/java/com/und/server/scenario/util/OrderCalculatorTest.java
+++ b/src/test/java/com/und/server/scenario/util/OrderCalculatorTest.java
@@ -84,7 +84,6 @@ class OrderCalculatorTest {
 
 		// then
 		assertThat(result).hasSize(3);
-		// 순서가 재정렬되었는지 확인
 		assertThat(result.get(0).getScenarioOrder()).isEqualTo(OrderCalculator.START_ORDER);
 		assertThat(result.get(1).getScenarioOrder()).isEqualTo(
 			OrderCalculator.START_ORDER + OrderCalculator.DEFAULT_ORDER);
@@ -93,19 +92,19 @@ class OrderCalculatorTest {
 	}
 
 	@Test
-	void Given_EmptyScenarioList_When_GetMaxOrderAfterReorder_Then_ReturnStartOrder() {
+	void Given_EmptyScenarioList_When_GetMinOrderAfterReorder_Then_ReturnStartOrder() {
 		// given
 		List<Scenario> emptyScenarios = List.of();
 
 		// when
-		Integer result = orderCalculator.getMaxOrderAfterReorder(emptyScenarios);
+		Integer result = orderCalculator.getMinOrderAfterReorder(emptyScenarios);
 
 		// then
 		assertThat(result).isEqualTo(OrderCalculator.START_ORDER);
 	}
 
 	@Test
-	void Given_ScenarioList_When_GetMaxOrderAfterReorder_Then_ReturnMaxOrderPlusDefault() {
+	void Given_ScenarioList_When_GetMinOrderAfterReorder_Then_ReturnMinOrderMinusDefault() {
 		// given
 		Scenario scenario1 = Scenario.builder()
 			.id(1L)
@@ -120,12 +119,10 @@ class OrderCalculatorTest {
 		List<Scenario> scenarios = new java.util.ArrayList<>(List.of(scenario1, scenario2));
 
 		// when
-		Integer result = orderCalculator.getMaxOrderAfterReorder(scenarios);
+		Integer result = orderCalculator.getMinOrderAfterReorder(scenarios);
 
 		// then
-		// 리오더링 후 마지막 시나리오의 order + DEFAULT_ORDER
-		assertThat(result).isEqualTo(
-			OrderCalculator.START_ORDER + OrderCalculator.DEFAULT_ORDER + OrderCalculator.DEFAULT_ORDER);
+		assertThat(result).isEqualTo(OrderCalculator.START_ORDER - OrderCalculator.DEFAULT_ORDER);
 	}
 
 }


### PR DESCRIPTION
### ✅ PR 타입
- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정

### 🪾 반영 브랜치
Bug/#104-scenario -> dev

### ✨ 변경 사항
- 시나리오 생성, 업데이트시 시나리오 목록 반환
- 시나리오 생성시 순서 가장 앞으로 배치
- 알림 동의 비동의에 따른 notification isActive 변경 api 추가

### 💯 테스트 결과
```
 kimsuyeon  ~/Documents/beforegoing-server   bug/#104-scenario  ./gradlew clean check test  

Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-09-10T15:20:59.836+09:00  INFO 41762 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///Users/kimsuyeon/Documents/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 26s
10 actionable tasks: 10 executed
 kimsuyeon  ~/Documents/beforegoing-server   bug/#104-scenario  

```

### 📂 관련 이슈
#104 

### 👀 리뷰어에게
