### PR TITLE
Rename ENDPOINT to HOSTNAME of datasource

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 # RDB
   datasource:
     driver-class-name: software.amazon.jdbc.Driver
-    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_ENDPOINT}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-1&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
+    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_HOSTNAME}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-1&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
     username: ${SPRING_DATASOURCE_USERNAME}
     hikari:
       max-lifetime: 720000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,7 +10,7 @@ spring:
 # RDB
   datasource:
     driver-class-name: software.amazon.jdbc.Driver
-    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_ENDPOINT}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-2&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
+    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_HOSTNAME}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-2&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
     username: ${SPRING_DATASOURCE_USERNAME}
     hikari:
       max-lifetime: 720000

--- a/src/main/resources/application-stg.yml
+++ b/src/main/resources/application-stg.yml
@@ -10,7 +10,7 @@ spring:
 # RDB
   datasource:
     driver-class-name: software.amazon.jdbc.Driver
-    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_ENDPOINT}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-2&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
+    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_HOSTNAME}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=ap-northeast-2&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
     username: ${SPRING_DATASOURCE_USERNAME}
     hikari:
       max-lifetime: 720000


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] refactor: 코드 리팩토링

### 🪾 반영 브랜치
<!-- 예) feat/login -> dev -->
refactor/#133-rdb-datasource

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
`SPRING_DATASOURCE_ENDPOINT`를 `SPRING_DATASOURCE_HOSTNAME`으로 변경

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
```
$ ./gradlew clean check test
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-09-28T09:55:52.134+09:00  INFO 140259 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///workspace/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 34s
10 actionable tasks: 10 executed
```

### 📂 관련 이슈
<!-- 예) #5 -->
#133

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
