### PR TITLE
🗃️ Change driver and url of RDB

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,8 +9,8 @@ spring:
 
 # RDB
   datasource:
-    driver-class-name: software.amazon.jdbc.Driver
-    url: jdbc:aws-wrapper:mysql://${SPRING_DATASOURCE_HOSTNAME}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?wrapperPlugins=iam&iamRegion=${SPRING_DATASOURCE_REGION}&sslMode=REQUIRED&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${SPRING_DATASOURCE_HOSTNAME}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE_NAME}?serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8
     username: ${SPRING_DATASOURCE_USERNAME}
     hikari:
       max-lifetime: 720000


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] sre: 시스템 관리 및 IT 인프라 자동화 작업

### 🪾 반영 브랜치
<!-- 예) feat/login -> dev -->
sre/#136-dev-rds -> dev

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
`application-dev.yml` 파일에서 `com.mysql.cj.jdbc.Driver`를 사용하도록 설정
datasource의 url에서 불필요한 요소 제거

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
```
$ ./gradlew clean check test
Starting a Gradle Daemon, 2 incompatible and 1 stopped Daemons could not be reused, use --status for details
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2025-10-13T15:44:40.562+09:00  INFO 87092 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///workspace/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 32s
10 actionable tasks: 10 executed
```

### 📂 관련 이슈
<!-- 예) #5 -->
#136

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
