### PR TITLE
Feat/member info

### DIFF
--- a/src/main/java/com/und/server/member/controller/MemberController.java
+++ b/src/main/java/com/und/server/member/controller/MemberController.java
@@ -27,8 +27,8 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	@GetMapping("/member")
-	public ResponseEntity<String> getMember(
+	@GetMapping("/member/nickname")
+	public ResponseEntity<String> getNickname(
 		@Parameter(hidden = true) @AuthMember final Long memberId
 	) {
 		final Member member = memberService.findMemberById(memberId);

--- a/src/main/java/com/und/server/member/controller/MemberController.java
+++ b/src/main/java/com/und/server/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.und.server.member.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.und.server.auth.filter.AuthMember;
 import com.und.server.member.dto.request.NicknameRequest;
 import com.und.server.member.dto.response.MemberResponse;
+import com.und.server.member.entity.Member;
 import com.und.server.member.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,6 +26,15 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
 	private final MemberService memberService;
+
+	@GetMapping("/member")
+	public ResponseEntity<String> getMember(
+		@Parameter(hidden = true) @AuthMember final Long memberId
+	) {
+		final Member member = memberService.findMemberById(memberId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(member.getNickname());
+	}
 
 	@PatchMapping("/member/nickname")
 	public ResponseEntity<MemberResponse> updateNickname(

--- a/src/test/java/com/und/server/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/und/server/member/controller/MemberControllerTest.java
@@ -1,11 +1,14 @@
 package com.und.server.member.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +31,7 @@ import com.und.server.common.exception.GlobalExceptionHandler;
 import com.und.server.common.exception.ServerException;
 import com.und.server.member.dto.request.NicknameRequest;
 import com.und.server.member.dto.response.MemberResponse;
+import com.und.server.member.entity.Member;
 import com.und.server.member.service.MemberService;
 
 @ExtendWith(MockitoExtension.class)
@@ -129,6 +133,59 @@ class MemberControllerTest {
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").value(memberId))
 			.andExpect(jsonPath("$.nickname").value(newNickname));
+	}
+
+	@Test
+	@DisplayName("Fails to get member and returns unauthorized when user is not authenticated")
+	void Given_UnauthenticatedUser_When_GetMember_Then_ReturnsUnauthorized() throws Exception {
+		// given
+		final String url = "/v1/member";
+		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
+
+		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
+		doThrow(new ServerException(errorResult))
+			.when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.get(url)
+		);
+
+		// then
+		resultActions.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value(errorResult.name()))
+			.andExpect(jsonPath("$.message").value(errorResult.getMessage()));
+	}
+
+	@Test
+	@DisplayName("Succeeds in getting member nickname for an authenticated user")
+	void Given_AuthenticatedUser_When_GetMember_Then_ReturnsOkWithNickname() throws Exception {
+		// given
+		final String url = "/v1/member";
+		final Long memberId = 1L;
+		final String nickname = "Chori";
+		final Member member = Member.builder()
+			.id(memberId)
+			.nickname(nickname)
+			.build();
+
+		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
+		doReturn(memberId).when(authMemberArgumentResolver).resolveArgument(any(), any(), any(), any());
+		doReturn(member).when(memberService).findMemberById(memberId);
+
+		// when
+		final ResultActions resultActions = mockMvc.perform(
+			MockMvcRequestBuilders.get(url)
+		);
+
+		// then
+		final String responseContent = resultActions
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString(StandardCharsets.UTF_8);
+		assertThat(responseContent).isEqualTo(nickname);
+		verify(memberService).findMemberById(memberId);
 	}
 
 	@Test

--- a/src/test/java/com/und/server/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/und/server/member/controller/MemberControllerTest.java
@@ -139,7 +139,7 @@ class MemberControllerTest {
 	@DisplayName("Fails to get member and returns unauthorized when user is not authenticated")
 	void Given_UnauthenticatedUser_When_GetMember_Then_ReturnsUnauthorized() throws Exception {
 		// given
-		final String url = "/v1/member";
+		final String url = "/v1/member/nickname";
 		final AuthErrorResult errorResult = AuthErrorResult.UNAUTHORIZED_ACCESS;
 
 		doReturn(true).when(authMemberArgumentResolver).supportsParameter(any());
@@ -161,7 +161,7 @@ class MemberControllerTest {
 	@DisplayName("Succeeds in getting member nickname for an authenticated user")
 	void Given_AuthenticatedUser_When_GetMember_Then_ReturnsOkWithNickname() throws Exception {
 		// given
-		final String url = "/v1/member";
+		final String url = "/v1/member/nickname";
 		final Long memberId = 1L;
 		final String nickname = "Chori";
 		final Member member = Member.builder()


### PR DESCRIPTION
### ✅ PR 타입
- [ ] feat: 사용자 이름 반환 api 추가


### 🪾 반영 브랜치
feat/member-info -> dev

### ✨ 변경 사항
 사용자 이름 반환 api 추가

### 💯 테스트 결과
```
 kimsuyeon  ~/Documents/beforegoing-server   feat/member-info ±  ./gradlew clean check test  
Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2026-01-14T13:17:23.839+09:00  INFO 10477 --- [server] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
Hibernate: drop table if exists location_notification cascade 
Hibernate: drop table if exists member cascade 
Hibernate: drop table if exists mission cascade 
Hibernate: drop table if exists notification cascade 
Hibernate: drop table if exists scenario cascade 
Hibernate: drop table if exists terms cascade 
Hibernate: drop table if exists time_notification cascade 

[Incubating] Problems report is available at: file:///Users/kimsuyeon/Documents/beforegoing-server/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 22s
10 actionable tasks: 10 executed
```

### 📂 관련 이슈

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
